### PR TITLE
feat: establish API v1 resource contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 ## Get latest from https://github.com/github/gitignore/blob/main/VisualStudio.gitignore
 
 # User-specific files
+.worktrees/
 *.rsuser
 *.suo
 *.user

--- a/docs/superpowers/plans/2026-07-26-api-v1-contract.md
+++ b/docs/superpowers/plans/2026-07-26-api-v1-contract.md
@@ -1,0 +1,75 @@
+# API v1 Contract Reset Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the legacy API routes with a tested `/api/v1` contract.
+
+**Architecture:** Controllers expose API DTOs only and delegate to existing use cases. A dedicated integration-test factory replaces SQL Server with isolated SQLite so endpoint tests exercise routing, validation, serialization, and persistence together.
+
+**Tech Stack:** .NET 8, ASP.NET Core controllers, EF Core, NUnit, FluentAssertions, WebApplicationFactory, SQLite.
+
+## Global Constraints
+
+- Remove legacy API routes; do not run compatibility routes in parallel.
+- Use plural `/api/v1` resource paths and RFC 7807 problem details.
+- Use `{ cents, currency }` for public money values and ISO 8601 UTC timestamps.
+- Add a failing test before each production-code change.
+- Run tests serially with `DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1 dotnet test ... -m:1 -p:BuildInParallel=false`.
+
+---
+
+### Task 1: Integration-test host
+
+**Files:**
+- Modify: `src/Xpense/Xpense.API/Program.cs`
+- Modify: `src/Xpense/Xpense.Tests/Xpense.Tests.csproj`
+- Create: `src/Xpense/Xpense.Tests/Infrastructure/WebApiTestFactory.cs`
+- Test: `src/Xpense/Xpense.Tests/Infrastructure/WebApiTestFactoryTests.cs`
+
+- [ ] Write a failing test that creates the factory and requests a v1 route.
+- [ ] Verify it fails because no `WebApiTestFactory` or v1 route exists.
+- [ ] Add `Microsoft.AspNetCore.Mvc.Testing` and `Microsoft.EntityFrameworkCore.Sqlite`; expose `partial class Program` and replace the production context registration with a SQLite in-memory context in the factory.
+- [ ] Verify the factory test passes and production SQL Server is not contacted.
+- [ ] Commit the test-host foundation.
+
+### Task 2: V1 account, category, tag, and merchant resources
+
+**Files:**
+- Modify: `src/Xpense/Xpense.API/Controllers/AccountController.cs`
+- Modify: `src/Xpense/Xpense.API/Controllers/CategoryController.cs`
+- Modify: `src/Xpense/Xpense.API/Controllers/TagController.cs`
+- Modify: `src/Xpense/Xpense.API/Controllers/MerchantController.cs`
+- Create: `src/Xpense/Xpense.Tests/Integration/V1ResourceEndpointTests.cs`
+
+- [ ] Write failing integration tests for plural v1 routes, `201` creation, and legacy-route `404` responses.
+- [ ] Verify they fail against the legacy routes.
+- [ ] Move routes to `/api/v1/...`, use resource IDs in path parameters, return `CreatedAtAction` and `NoContent` where applicable, and remove response envelopes.
+- [ ] Verify route and status tests pass.
+- [ ] Commit the resource-route slice.
+
+### Task 3: Unified transaction and transfer contract
+
+**Files:**
+- Modify: `src/Xpense/Xpense.API/Controllers/TransactionController.cs`
+- Create: `src/Xpense/Xpense.API/Models/Requests/CreateTransactionRequest.cs`
+- Create: `src/Xpense/Xpense.API/Models/Responses/V1TransactionResponse.cs`
+- Create: `src/Xpense/Xpense.Tests/Integration/V1TransactionEndpointTests.cs`
+- Test: `src/Xpense/Xpense.Tests/Unit/CreateTransactionRequestTests.cs`
+
+- [ ] Write failing unit and integration tests for `POST /api/v1/transactions` with `income` and `expense` types and for filtered paging.
+- [ ] Verify the tests fail because the unified contract does not exist.
+- [ ] Map the public request to the existing deposit/withdraw use cases, return a single response DTO, and return validation problem details for unsupported types.
+- [ ] Add the separate `POST /api/v1/transfers` contract only when its use case is implemented; otherwise return no transfer route in this slice.
+- [ ] Verify tests pass and commit the transaction slice.
+
+### Task 4: Analytics, error normalization, and full regression
+
+**Files:**
+- Modify: `src/Xpense/Xpense.API/Controllers/AnalyticsController.cs`
+- Modify: `src/Xpense/Xpense.API/Helpers/XpenseController.cs`
+- Test: `src/Xpense/Xpense.Tests/Integration/V1AnalyticsAndErrorsTests.cs`
+
+- [ ] Write failing integration tests for `GET /api/v1/analytics/spending/by-category` and RFC 7807 validation/not-found errors.
+- [ ] Verify expected failures.
+- [ ] Move analytics to the v1 route and replace custom success/error envelopes with the agreed contracts.
+- [ ] Run the complete serial test suite, inspect warnings and failures, and commit the completed reset.

--- a/docs/superpowers/plans/2026-07-26-api-v1-contract.md
+++ b/docs/superpowers/plans/2026-07-26-api-v1-contract.md
@@ -62,6 +62,33 @@
 - [ ] Add the separate `POST /api/v1/transfers` contract only when its use case is implemented; otherwise return no transfer route in this slice.
 - [ ] Verify tests pass and commit the transaction slice.
 
+### Task 3a: Financial correctness and transaction read model
+
+**Files:**
+- Modify: `src/Xpense/Xpense.Services/ValueObjects/Money.cs`
+- Modify: transaction repository, abstraction, and use-case files needed for transaction lookup and pagination totals
+- Test: `src/Xpense/Xpense.Tests/Unit/MoneyTests.cs`
+- Test: `src/Xpense/Xpense.Tests/Integration/V1TransactionReadTests.cs`
+
+- [ ] Write a failing unit test that `Money.OfCents(1234).ToSingle()` is `12.34m`.
+- [ ] Fix the calculation to divide by `100m` and verify the test passes.
+- [ ] Write failing integration tests for `GET /api/v1/transactions/{id}` and paged results with `totalItems`.
+- [ ] Add the repository/use-case/controller support needed to make a created transaction retrievable and paging totals truthful.
+- [ ] Verify the focused tests pass and commit this prerequisite slice.
+
+### Task 3b: Atomic transfer domain model
+
+**Files:**
+- Modify: service commands, entities, persistence mappings, repositories, use cases, and DI registration needed for transfers
+- Test: `src/Xpense/Xpense.Tests/Unit/TransferTransactionUseCaseTests.cs`
+- Test: `src/Xpense/Xpense.Tests/Integration/V1TransferEndpointTests.cs`
+
+- [ ] Write failing unit tests that a transfer debits one account, credits another, rejects identical accounts, and persists correlated legs atomically.
+- [ ] Verify the tests fail because no transfer use case exists.
+- [ ] Implement the smallest explicit transfer aggregate/leg model and transactional use case; do not expose a route until those tests pass.
+- [ ] Add `POST /api/v1/transfers` integration tests for the successful and rejected cases.
+- [ ] Verify the focused tests pass and commit the transfer slice.
+
 ### Task 4: Analytics, error normalization, and full regression
 
 **Files:**

--- a/docs/superpowers/specs/2026-07-26-api-v1-contract-design.md
+++ b/docs/superpowers/specs/2026-07-26-api-v1-contract-design.md
@@ -1,0 +1,63 @@
+# API v1 Contract Reset
+
+## Goal
+
+Replace the early singular, action-based HTTP API with a stable, MCP-friendly
+resource API for a personal-finance product. This is a hard cutover: legacy
+routes are removed rather than supported in parallel.
+
+## Route and resource conventions
+
+All endpoints use the `/api/v1` prefix and plural nouns. Resource URLs use the
+database-backed `id`, not an account number. Successful responses return the
+resource directly. Create operations return `201 Created` with a `Location`
+header; deletion returns `204 No Content`; failures use RFC 7807 problem
+details.
+
+`GET` collection responses that support paging return:
+
+```json
+{
+  "items": [],
+  "page": 1,
+  "pageSize": 25,
+  "totalItems": 0,
+  "totalPages": 0
+}
+```
+
+Money crosses the boundary as `{ "cents": 1234, "currency": "EUR" }`.
+Dates use ISO 8601 UTC timestamps. Public request/response DTOs never expose
+service-layer command or entity types.
+
+## Resources
+
+* `GET|POST /api/v1/accounts`, `GET|PUT|DELETE /api/v1/accounts/{id}`
+* `GET|POST /api/v1/categories`, `GET|PUT|DELETE /api/v1/categories/{id}`
+* `GET|POST /api/v1/tags`, `GET|PUT|DELETE /api/v1/tags/{id}`
+* `GET /api/v1/merchants`
+* `GET|POST /api/v1/transactions`, `GET /api/v1/transactions/{id}`
+* `POST /api/v1/transfers`
+* `GET /api/v1/analytics/spending/by-category`
+
+Transactions use `type` (`income` or `expense`) and a single request shape.
+Transfers are deliberately separate because they affect both source and target
+accounts.
+
+## Testing
+
+Tests are NUnit. Unit tests exercise input validation and request-to-command
+mapping without HTTP infrastructure. Integration tests use `WebApiTestFactory`
+and a per-test SQLite in-memory database, replacing the production SQL Server
+registration. The factory controls schema creation and seed data, so integration
+tests neither require nor modify a developer database.
+
+Every endpoint change follows red-green-refactor. Integration tests verify the
+new response/status contracts, validation failures, pagination, and that legacy
+routes return `404`.
+
+## Scope boundaries
+
+This change does not add receipt OCR, an MCP server, bank connections,
+authentication, workspace tenancy, or web-client work. It creates the HTTP
+contract and test foundation those capabilities will later use.

--- a/src/Xpense/Xpense.API/Controllers/AccountController.cs
+++ b/src/Xpense/Xpense.API/Controllers/AccountController.cs
@@ -14,7 +14,7 @@ namespace Xpense.API.Controllers
 {
     [ApiController]
     [ApiVersion("1.0")]
-    [Route("api/account")]
+    [Route("api/v1/accounts")]
     public class AccountController(
         CreateAccountUseCase createAccount,
         GetAllAccountsUseCase getAllAccountsAccounts,

--- a/src/Xpense/Xpense.API/Controllers/AccountController.cs
+++ b/src/Xpense/Xpense.API/Controllers/AccountController.cs
@@ -19,24 +19,20 @@ namespace Xpense.API.Controllers
         CreateAccountUseCase createAccount,
         GetAllAccountsUseCase getAllAccountsAccounts,
         DeleteAccountUseCase deleteAccountUseCase,
-        GetAccountByNumberUseCase getAccountByNumberUseCase,
         UpdateAccountUseCase updateAccountUseCase,
         ILogger logger) : XpenseController
     {
         [HttpGet(
-            "{accountNumber:minlength(10):maxlength(10)}",
-            Name = "Get Account By (Account Number)"
+            "{id:int}",
+            Name = "Get Account By Id"
         )]
         [ProducesResponseType<AccountResponse>(StatusCodes.Status200OK, "application/json")]
-        public async Task<IActionResult> GetByAccountNumber(string accountNumber)
+        public async Task<IActionResult> GetById(int id)
         {
             try
             {
-                if (string.IsNullOrWhiteSpace(accountNumber) || accountNumber.Length != 10)
-                    return ValidationProblem($"Please provide a valid account accountNumber");
-
-                var account = await getAccountByNumberUseCase.Execute(accountNumber);
-                return Ok(AccountResponse.Of(account));
+                var account = await FindById(id);
+                return new OkObjectResult(AccountResponse.Of(account));
             }
             catch (AccountNotFoundException ex)
             {
@@ -48,7 +44,7 @@ namespace Xpense.API.Controllers
         public async Task<IActionResult> Get()
         {
             var accounts = await getAllAccountsAccounts.Execute();
-            return Ok(accounts.Select(AccountResponse.Of));
+            return new OkObjectResult(accounts.Select(AccountResponse.Of));
         }
 
         [HttpPost("", Name = "Create Account", Order = 1)]
@@ -57,7 +53,7 @@ namespace Xpense.API.Controllers
             try
             {
                 var createdAccount = await createAccount.Handle(request.ToCommand());
-                return Ok(AccountResponse.Of(createdAccount));
+                return CreatedAtAction(nameof(GetById), new { id = createdAccount.Id }, AccountResponse.Of(createdAccount));
             }
             catch (AccountCreationFailedException exception)
             {
@@ -67,18 +63,16 @@ namespace Xpense.API.Controllers
         }
 
         [HttpDelete(
-            "{accountNumber:minlength(10):maxlength(10)}",
-            Name = "Delete Account By Number"
+            "{id:int}",
+            Name = "Delete Account By Id"
         )]
-        public async Task<IActionResult> Delete(string number)
+        public async Task<IActionResult> Delete(int id)
         {
             try
             {
-                if (string.IsNullOrWhiteSpace(number) || number.Length != 10)
-                    return ValidationProblem($"Please provide a valid account accountNumber");
-
-                await deleteAccountUseCase.Handle(number);
-                return Ok("Account Deleted Successfully");
+                var account = await FindById(id);
+                await deleteAccountUseCase.Handle(account.AccountNumber);
+                return NoContent();
             }
             catch (AccountNotFoundException exception)
             {
@@ -92,15 +86,18 @@ namespace Xpense.API.Controllers
             }
         }
 
-        [HttpPut(Name = "Update account")]
-        public async Task<IActionResult> Update([FromBody] UpdateAccountRequest request)
+        [HttpPut("{id:int}", Name = "Update account")]
+        public async Task<IActionResult> Update(int id, [FromBody] UpdateAccountRequest request)
         {
             try
             {
                 if (request == null || !ModelState.IsValid)
                     return ValidationProblem($"Invalid Patch Request: {ModelState}");
+
+                var account = await FindById(id);
+                request.Number = account.AccountNumber;
                 var result = await updateAccountUseCase.Handle(request.ToCommand());
-                return Ok(AccountResponse.Of(result));
+                return new OkObjectResult(AccountResponse.Of(result));
             }
             catch (AccountNotFoundException exception)
             {
@@ -112,6 +109,12 @@ namespace Xpense.API.Controllers
                 logger.Warning(exception.Message);
                 return Problem(exception.Message);
             }
+        }
+
+        private async Task<Xpense.Services.Entities.Account> FindById(int id)
+        {
+            var account = (await getAllAccountsAccounts.Execute()).SingleOrDefault(account => account.Id == id);
+            return account ?? throw new AccountNotFoundException(id.ToString());
         }
     }
 }

--- a/src/Xpense/Xpense.API/Controllers/AccountController.cs
+++ b/src/Xpense/Xpense.API/Controllers/AccountController.cs
@@ -18,6 +18,7 @@ namespace Xpense.API.Controllers
     public class AccountController(
         CreateAccountUseCase createAccount,
         GetAllAccountsUseCase getAllAccountsAccounts,
+        GetAccountByIdUseCase getAccountByIdUseCase,
         DeleteAccountUseCase deleteAccountUseCase,
         UpdateAccountUseCase updateAccountUseCase,
         ILogger logger) : XpenseController
@@ -31,7 +32,7 @@ namespace Xpense.API.Controllers
         {
             try
             {
-                var account = await FindById(id);
+                var account = await getAccountByIdUseCase.Execute(id);
                 return new OkObjectResult(AccountResponse.Of(account));
             }
             catch (AccountNotFoundException ex)
@@ -70,8 +71,7 @@ namespace Xpense.API.Controllers
         {
             try
             {
-                var account = await FindById(id);
-                await deleteAccountUseCase.Handle(account.AccountNumber);
+                await deleteAccountUseCase.Handle(id);
                 return NoContent();
             }
             catch (AccountNotFoundException exception)
@@ -94,9 +94,7 @@ namespace Xpense.API.Controllers
                 if (request == null || !ModelState.IsValid)
                     return ValidationProblem($"Invalid Patch Request: {ModelState}");
 
-                var account = await FindById(id);
-                request.Number = account.AccountNumber;
-                var result = await updateAccountUseCase.Handle(request.ToCommand());
+                var result = await updateAccountUseCase.Handle(request.ToCommand(id));
                 return new OkObjectResult(AccountResponse.Of(result));
             }
             catch (AccountNotFoundException exception)
@@ -109,12 +107,6 @@ namespace Xpense.API.Controllers
                 logger.Warning(exception.Message);
                 return Problem(exception.Message);
             }
-        }
-
-        private async Task<Xpense.Services.Entities.Account> FindById(int id)
-        {
-            var account = (await getAllAccountsAccounts.Execute()).SingleOrDefault(account => account.Id == id);
-            return account ?? throw new AccountNotFoundException(id.ToString());
         }
     }
 }

--- a/src/Xpense/Xpense.API/Controllers/CategoryController.cs
+++ b/src/Xpense/Xpense.API/Controllers/CategoryController.cs
@@ -10,7 +10,7 @@ using Xpense.Services.Features.Categories.UseCases;
 
 namespace Xpense.API.Controllers
 {
-    [Route("api/category")]
+    [Route("api/v1/categories")]
     [ApiController]
     public class CategoryController(
         CreateCategoryUseCase createCategory,
@@ -25,7 +25,7 @@ namespace Xpense.API.Controllers
         public async Task<IActionResult> Get()
         {
             var categories = await getAllCategoriesUseCase.Execute();
-            return Ok(categories.Select(CategoryResponse.Of));
+            return new OkObjectResult(categories.Select(CategoryResponse.Of));
         }
 
         [HttpGet("{id:int}")]
@@ -34,7 +34,7 @@ namespace Xpense.API.Controllers
             try
             {
                 var result = await getCategoryByIdUseCase.Execute(id);
-                return Ok(result);
+                return new OkObjectResult(CategoryResponse.Of(result));
             }
             catch (CategoryNotFoundException exception)
             {
@@ -49,7 +49,7 @@ namespace Xpense.API.Controllers
             try
             {
                 await deleteCategoryByIdUseCase.Handle(id);
-                return Ok("CategoryId Deleted Successfully!");
+                return NoContent();
             }
             catch (CategoryDeletionFailedException exception)
             {
@@ -64,7 +64,7 @@ namespace Xpense.API.Controllers
             try
             {
                 var category = await createCategory.Handle(request.ToCommand());
-                return Ok(CreateCategoryResponse.Of(category));
+                return CreatedAtAction(nameof(GetById), new { id = category.Id }, CategoryResponse.Of(category));
             }
             catch (CategoryCreationFailedException exception)
             {
@@ -73,13 +73,14 @@ namespace Xpense.API.Controllers
             }
         }
 
-        [HttpPut]
-        public async Task<IActionResult> Update([FromBody] UpdateCategoryRequest request)
+        [HttpPut("{id:int}")]
+        public async Task<IActionResult> Update(int id, [FromBody] UpdateCategoryRequest request)
         {
             try
             {
+                request.Id = id;
                 var category = await updateCategoryUseCase.Handle(request.ToCommand());
-                return Ok(CategoryResponse.Of(category));
+                return new OkObjectResult(CategoryResponse.Of(category));
             }
             catch (CategoryNotFoundException exception)
             {

--- a/src/Xpense/Xpense.API/Controllers/MerchantController.cs
+++ b/src/Xpense/Xpense.API/Controllers/MerchantController.cs
@@ -7,7 +7,7 @@ using Xpense.Services.Features.Merchants.UseCases;
 
 namespace Xpense.API.Controllers
 {
-    [Route("api/merchant")]
+    [Route("api/v1/merchants")]
     [ApiController]
     public class MerchantController(
         GetAllMerchantsUseCase getAllMerchantsUse
@@ -17,7 +17,7 @@ namespace Xpense.API.Controllers
         public async Task<IActionResult> Get()
         {
             var merchants = await getAllMerchantsUse.Execute();
-            return Ok(merchants.Select(MerchantResponse.Of));
+            return new OkObjectResult(merchants.Select(MerchantResponse.Of));
         }
     }
 }

--- a/src/Xpense/Xpense.API/Controllers/TagController.cs
+++ b/src/Xpense/Xpense.API/Controllers/TagController.cs
@@ -11,7 +11,7 @@ using Xpense.Services.Features.Tags.UseCases;
 
 namespace Xpense.API.Controllers;
 
-[Route("api/tag")]
+[Route("api/v1/tags")]
 [ApiController]
 public class TagController(
     GetAllTagsUseCase getAllTagsUseCase,
@@ -26,7 +26,7 @@ public class TagController(
     public async Task<IActionResult> Get()
     {
         var tags = await getAllTagsUseCase.Execute();
-        return Ok(tags.Select(TagResponse.Of));
+        return new OkObjectResult(tags.Select(TagResponse.Of));
     }
 
     [HttpGet("{id:int}")]
@@ -35,7 +35,7 @@ public class TagController(
         try
         {
             var tag = await getTagByIdUseCase.Execute(id);
-            return Ok(TagResponse.Of(tag));
+            return new OkObjectResult(TagResponse.Of(tag));
         }
         catch (TagNotFoundException exception)
         {
@@ -50,7 +50,7 @@ public class TagController(
         try
         {
             await deleteTagUseCase.Handle(id);
-            return Ok("Tag Deleted Successfully!");
+            return NoContent();
         }
         catch (TagNotFoundException exception)
         {
@@ -73,7 +73,7 @@ public class TagController(
             request.FgColorHex = TrimHashSign(request.FgColorHex);
 
             var tag = await createTagUseCase.Handle(request.ToCommand());
-            return Ok(CreateTagResponse.Of(tag));
+            return CreatedAtAction(nameof(Get), new { id = tag.Id }, TagResponse.Of(tag));
         }
         catch (TagCreationFailedException exception)
         {
@@ -82,16 +82,17 @@ public class TagController(
         }
     }
 
-    [HttpPut]
-    public async Task<IActionResult> Update([FromBody] UpdateTagRequest request)
+    [HttpPut("{id:int}")]
+    public async Task<IActionResult> Update(int id, [FromBody] UpdateTagRequest request)
     {
         try
         {
+            request.Id = id;
             request.BgColorHex = TrimHashSign(request.BgColorHex);
             request.FgColorHex = TrimHashSign(request.FgColorHex);
 
             var tag = await updateTagUseCase.Handle(request.ToCommand());
-            return Ok(TagResponse.Of(tag));
+            return new OkObjectResult(TagResponse.Of(tag));
         }
         catch (TagNotFoundException exception)
         {

--- a/src/Xpense/Xpense.API/Controllers/TagController.cs
+++ b/src/Xpense/Xpense.API/Controllers/TagController.cs
@@ -30,7 +30,7 @@ public class TagController(
     }
 
     [HttpGet("{id:int}")]
-    public async Task<IActionResult> Get([FromRoute] int id)
+    public async Task<IActionResult> GetById([FromRoute] int id)
     {
         try
         {
@@ -73,7 +73,7 @@ public class TagController(
             request.FgColorHex = TrimHashSign(request.FgColorHex);
 
             var tag = await createTagUseCase.Handle(request.ToCommand());
-            return CreatedAtAction(nameof(Get), new { id = tag.Id }, TagResponse.Of(tag));
+            return CreatedAtAction(nameof(GetById), new { id = tag.Id }, TagResponse.Of(tag));
         }
         catch (TagCreationFailedException exception)
         {

--- a/src/Xpense/Xpense.API/Models/Requests/UpdateAccountRequest.cs
+++ b/src/Xpense/Xpense.API/Models/Requests/UpdateAccountRequest.cs
@@ -2,11 +2,10 @@ using Xpense.Services.Features.Accounts.Commands;
 
 namespace Xpense.API.Models.Requests;
 
-public class UpdateAccountRequest(string number, string name, bool isDefault)
+public class UpdateAccountRequest(string name, bool isDefault)
 {
-    public string Number { get; set; } = number;
     public string Name { get; set; } = name;
     public bool IsDefault { get; set; } = isDefault;
 
-    public UpdateAccountCommand ToCommand() => new(Number, Name, IsDefault);
+    public UpdateAccountCommand ToCommand(int id) => new(id, Name, IsDefault);
 }

--- a/src/Xpense/Xpense.API/Program.cs
+++ b/src/Xpense/Xpense.API/Program.cs
@@ -29,9 +29,9 @@ builder.Services.ConfigureApiVersioning();
 
 var app = builder.Build();
 
-// TODO: Move this somewhere else
-using (var scope = app.Services.CreateScope())
+if (!app.Environment.IsEnvironment("Testing"))
 {
+    using var scope = app.Services.CreateScope();
     var services = scope.ServiceProvider;
     var context = services.GetRequiredService<XpenseDbContext>();
     context.Database.EnsureCreated();
@@ -63,3 +63,5 @@ if (app.Environment.IsDevelopment())
 }
 
 app.Run();
+
+public partial class Program;

--- a/src/Xpense/Xpense.Services/Exceptions/AccountExceptions.cs
+++ b/src/Xpense/Xpense.Services/Exceptions/AccountExceptions.cs
@@ -1,7 +1,17 @@
 namespace Xpense.Services.Exceptions;
 
-public class AccountNotFoundException(string accountNumber, Exception? innerException = null)
-    : XpenseException($"Account with number {accountNumber} was not found!", innerException);
+public class AccountNotFoundException : XpenseException
+{
+    public AccountNotFoundException(string accountNumber, Exception? innerException = null)
+        : base($"Account with number {accountNumber} was not found!", innerException)
+    {
+    }
+
+    public AccountNotFoundException(int id, Exception? innerException = null)
+        : base($"Account with id {id} was not found!", innerException)
+    {
+    }
+}
 
 public class DefaultAccountNotFoundException(Exception? innerException = null)
     : XpenseException($"Account was not specified and no default account was found! ", innerException);

--- a/src/Xpense/Xpense.Services/Features/Accounts/Commands/UpdateAccountCommand.cs
+++ b/src/Xpense/Xpense.Services/Features/Accounts/Commands/UpdateAccountCommand.cs
@@ -1,8 +1,8 @@
 namespace Xpense.Services.Features.Accounts.Commands;
 
-public class UpdateAccountCommand(string number, string name, bool isDefault)
+public class UpdateAccountCommand(int id, string name, bool isDefault)
 {
-    public string Number { get; set; } = number;
+    public int Id { get; set; } = id;
     public string Name { get; set; } = name;
     public bool IsDefault { get; set; } = isDefault;
 }

--- a/src/Xpense/Xpense.Services/Features/Accounts/Usecases/CreateAccountUseCase.cs
+++ b/src/Xpense/Xpense.Services/Features/Accounts/Usecases/CreateAccountUseCase.cs
@@ -16,6 +16,7 @@ public class CreateAccountUseCase(IAccountRepository repository) : ICommandResul
             Balance = request.Balance,
             AccountNumber = repository.GetNextAccountNumber(),
             IsDefaultAccount = !repository.HasDefaultAccount(),
+            CreatedOn = DateTime.Now,
         };
 
         repository.Create(account);

--- a/src/Xpense/Xpense.Services/Features/Accounts/Usecases/DeleteAccountUseCase.cs
+++ b/src/Xpense/Xpense.Services/Features/Accounts/Usecases/DeleteAccountUseCase.cs
@@ -4,15 +4,19 @@ using Xpense.Services.Exceptions;
 
 namespace Xpense.Services.Features.Accounts.Usecases;
 
-public class DeleteAccountUseCase(IAccountRepository repository): ICommandHandler<string>
+public class DeleteAccountUseCase(IAccountRepository repository): ICommandHandler<int>
 {
-    public async Task Handle(string accountNumber)
+    public async Task Handle(int id)
     {
-       repository.DeleteAccountByNumber(accountNumber);
+       var account = await repository.GetById(id);
+       if (account == null)
+           throw new AccountNotFoundException(id);
+
+       repository.Delete(account);
        var result = await repository.SaveChanges();
        if (result < 1)
        {
-           throw new AccountUpdateFailedException(accountNumber);
+           throw new AccountUpdateFailedException(id.ToString());
        }
     }
 }

--- a/src/Xpense/Xpense.Services/Features/Accounts/Usecases/GetAccountByIdUseCase.cs
+++ b/src/Xpense/Xpense.Services/Features/Accounts/Usecases/GetAccountByIdUseCase.cs
@@ -1,0 +1,15 @@
+using Xpense.Services.Abstract.Persistence;
+using Xpense.Services.Abstract.UseCases;
+using Xpense.Services.Entities;
+using Xpense.Services.Exceptions;
+
+namespace Xpense.Services.Features.Accounts.Usecases;
+
+public class GetAccountByIdUseCase(IAccountRepository repository) : IQueryParamHandler<int, Account>
+{
+    public async Task<Account> Execute(int id, CancellationToken cancellationToken = default)
+    {
+        var account = await repository.GetById(id);
+        return account ?? throw new AccountNotFoundException(id);
+    }
+}

--- a/src/Xpense/Xpense.Services/Features/Accounts/Usecases/UpdateAccountUseCase.cs
+++ b/src/Xpense/Xpense.Services/Features/Accounts/Usecases/UpdateAccountUseCase.cs
@@ -11,13 +11,16 @@ public class UpdateAccountUseCase(IAccountRepository repository)
 {
     public async Task<Account> Handle(UpdateAccountCommand command)
     {
-        var account = await repository.GetAccountByNumber(command.Number);
+        var account = await repository.GetById(command.Id);
+        if (account == null)
+            throw new AccountNotFoundException(command.Id);
+
         account.Name = command.Name;
         account.IsDefaultAccount = command.IsDefault;
         repository.Update(account);
         var result = await repository.SaveChanges();
         if (result < 1)
-            throw new AccountUpdateFailedException(command.Number);
+            throw new AccountUpdateFailedException(command.Id.ToString());
         return account;
     }
 }

--- a/src/Xpense/Xpense.Services/Features/Categories/UseCases/CreateCategoryUseCase.cs
+++ b/src/Xpense/Xpense.Services/Features/Categories/UseCases/CreateCategoryUseCase.cs
@@ -21,7 +21,8 @@ public class CreateCategoryUseCase(
         var category = new Category()
         {
             Label = command.Name,
-            Priority = priority
+            Priority = priority,
+            CreatedOn = DateTime.Now
         };
 
         repository.Create(category);

--- a/src/Xpense/Xpense.Services/Features/Categories/UseCases/GetCategoryByIdUseCase.cs
+++ b/src/Xpense/Xpense.Services/Features/Categories/UseCases/GetCategoryByIdUseCase.cs
@@ -9,7 +9,7 @@ public class GetCategoryByIdUseCase(ICategoryRepository repository) : IQueryPara
 {
     public async Task<Category> Execute(int accountNumber, CancellationToken cancellationToken = default)
     {
-        var category = await repository.GetById(accountNumber);
+        var category = await repository.GetWithById(accountNumber, category => category.Priority);
         if (category == null)
             throw new CategoryNotFoundException(accountNumber);
         return category;

--- a/src/Xpense/Xpense.Services/Features/Tags/Commands/CreateTagCommand.cs
+++ b/src/Xpense/Xpense.Services/Features/Tags/Commands/CreateTagCommand.cs
@@ -12,6 +12,7 @@ public class CreateTagCommand(string label, string bgColorHex, string fgColorHex
     {
         Label = Label,
         BgColorHex = BgColorHex,
-        FgColorHex = FgColorHex
+        FgColorHex = FgColorHex,
+        CreatedOn = DateTime.Now
     };
 }

--- a/src/Xpense/Xpense.Tests/Infrastructure/WebApiTestFactory.cs
+++ b/src/Xpense/Xpense.Tests/Infrastructure/WebApiTestFactory.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Xpense.Persistence;
+
+namespace Xpense.Tests.Infrastructure;
+
+public sealed class WebApiTestFactory : WebApplicationFactory<Program>
+{
+    private readonly SqliteConnection connection = new("Data Source=:memory:");
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.ConfigureServices(services =>
+        {
+            services.RemoveAll<DbContextOptions<XpenseDbContext>>();
+            services.RemoveAll<XpenseDbContext>();
+            connection.Open();
+            services.AddDbContext<XpenseDbContext>(options => options.UseSqlite(connection));
+        });
+    }
+
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        var host = base.CreateHost(builder);
+        using var scope = host.Services.CreateScope();
+        scope.ServiceProvider.GetRequiredService<XpenseDbContext>().Database.EnsureCreated();
+        return host;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+            connection.Dispose();
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/Xpense/Xpense.Tests/Integration/V1ResourceEndpointTests.cs
+++ b/src/Xpense/Xpense.Tests/Integration/V1ResourceEndpointTests.cs
@@ -23,11 +23,15 @@ public class V1ResourceEndpointTests
         using var factory = new WebApiTestFactory();
         using var client = factory.CreateClient();
 
+        await SeedAccount(factory);
+
         var response = await client.GetAsync(route);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         document.RootElement.ValueKind.Should().Be(JsonValueKind.Array);
+        if (route == "/api/v1/accounts")
+            document.RootElement[0].GetProperty("label").GetString().Should().Be("Cash");
     }
 
     [TestCase("/api/category")]
@@ -115,6 +119,106 @@ public class V1ResourceEndpointTests
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
 
+    [Test]
+    public async Task Get_accounts_by_id_returns_the_direct_resource()
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+        await SeedAccount(factory);
+
+        var response = await client.GetAsync("/api/v1/accounts/1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("id").GetInt32().Should().Be(1);
+        document.RootElement.GetProperty("label").GetString().Should().Be("Cash");
+    }
+
+    [Test]
+    public async Task Put_accounts_updates_the_resource_id_and_delete_returns_no_content()
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+        await SeedAccount(factory);
+
+        var updateResponse = await client.PutAsync(
+            "/api/v1/accounts/1",
+            JsonBody("{\"name\":\"Updated Cash\",\"isDefault\":false}"));
+        var deleteResponse = await client.DeleteAsync("/api/v1/accounts/1");
+
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await updateResponse.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("label").GetString().Should().Be("Updated Cash");
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Test]
+    public async Task Get_categories_by_id_returns_the_direct_resource()
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+        await SeedCategory(factory);
+
+        var response = await client.GetAsync("/api/v1/categories/1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("id").GetInt32().Should().Be(1);
+        document.RootElement.GetProperty("label").GetString().Should().Be("Food");
+    }
+
+    [Test]
+    public async Task Put_categories_updates_the_resource_id_and_delete_returns_no_content()
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+        await SeedCategory(factory);
+
+        var updateResponse = await client.PutAsync(
+            "/api/v1/categories/1",
+            JsonBody("{\"name\":\"Dining\",\"priorityId\":1}"));
+        var deleteResponse = await client.DeleteAsync("/api/v1/categories/1");
+
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await updateResponse.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("label").GetString().Should().Be("Dining");
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Test]
+    public async Task Put_tags_updates_the_resource_id_and_delete_returns_no_content()
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+        var createResponse = await client.PostAsync(
+            "/api/v1/tags",
+            JsonBody("{\"label\":\"Travel\",\"bgColorHex\":\"#ffffff\",\"fgColorHex\":\"#000000\"}"));
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var updateResponse = await client.PutAsync(
+            "/api/v1/tags/1",
+            JsonBody("{\"name\":\"Holiday\",\"bgColorHex\":\"#123456\",\"fgColorHex\":\"#abcdef\"}"));
+        var deleteResponse = await client.DeleteAsync("/api/v1/tags/1");
+
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await updateResponse.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("label").GetString().Should().Be("Holiday");
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [TestCase("/api/account")]
+    [TestCase("/api/account/1000000000")]
+    [TestCase("/api/v1/accounts/1000000000")]
+    public async Task Legacy_account_number_item_and_collection_put_routes_are_not_available(string route)
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PutAsync(route, JsonBody("{\"name\":\"Cash\",\"isDefault\":true}"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
     private static StringContent JsonBody(string json) => new(json, Encoding.UTF8, "application/json");
 
     private static async Task SeedAccount(WebApiTestFactory factory)
@@ -140,6 +244,20 @@ public class V1ResourceEndpointTests
         {
             Label = "Normal",
             Weight = 1,
+            CreatedOn = DateTime.UtcNow
+        });
+        await dbContext.SaveChangesAsync();
+    }
+
+    private static async Task SeedCategory(WebApiTestFactory factory)
+    {
+        await SeedPriority(factory);
+        using var scope = factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<XpenseDbContext>();
+        dbContext.Categories.Add(new Category
+        {
+            Label = "Food",
+            PriorityId = 1,
             CreatedOn = DateTime.UtcNow
         });
         await dbContext.SaveChangesAsync();

--- a/src/Xpense/Xpense.Tests/Integration/V1ResourceEndpointTests.cs
+++ b/src/Xpense/Xpense.Tests/Integration/V1ResourceEndpointTests.cs
@@ -1,0 +1,147 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Xpense.Persistence;
+using Xpense.Services.Entities;
+using Xpense.Tests.Infrastructure;
+
+namespace Xpense.Tests.Integration;
+
+[TestFixture]
+public class V1ResourceEndpointTests
+{
+    [TestCase("/api/v1/accounts")]
+    [TestCase("/api/v1/categories")]
+    [TestCase("/api/v1/tags")]
+    [TestCase("/api/v1/merchants")]
+    public async Task Get_resource_collections_uses_plural_v1_routes_and_returns_resources_directly(string route)
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync(route);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.ValueKind.Should().Be(JsonValueKind.Array);
+    }
+
+    [TestCase("/api/category")]
+    [TestCase("/api/tag")]
+    [TestCase("/api/merchant")]
+    public async Task Legacy_singular_resource_routes_are_not_available(string route)
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync(route);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Test]
+    public async Task Post_accounts_returns_created_resource_at_its_id_route()
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+        await SeedAccount(factory);
+
+        var response = await client.PostAsync(
+            "/api/v1/accounts",
+            JsonBody("{\"name\":\"Savings\",\"balance\":123.45}"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.Location.Should().Be(new Uri("http://localhost/api/v1/accounts/2"));
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("id").GetInt32().Should().Be(2);
+        document.RootElement.GetProperty("label").GetString().Should().Be("Savings");
+    }
+
+    [Test]
+    public async Task Post_categories_returns_created_resource_at_its_id_route()
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+        await SeedPriority(factory);
+
+        var response = await client.PostAsync(
+            "/api/v1/categories",
+            JsonBody("{\"name\":\"Food\",\"priorityId\":1}"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.Location.Should().Be(new Uri("http://localhost/api/v1/categories/1"));
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("id").GetInt32().Should().Be(1);
+        document.RootElement.GetProperty("label").GetString().Should().Be("Food");
+    }
+
+    [Test]
+    public async Task Post_tags_returns_created_resource_at_its_id_route()
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync(
+            "/api/v1/tags",
+            JsonBody("{\"label\":\"Travel\",\"bgColorHex\":\"#ffffff\",\"fgColorHex\":\"#000000\"}"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.Location.Should().Be(new Uri("http://localhost/api/v1/tags/1"));
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("id").GetInt32().Should().Be(1);
+        document.RootElement.GetProperty("label").GetString().Should().Be("Travel");
+
+        var getResponse = await client.GetAsync(response.Headers.Location);
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Delete_tags_uses_the_resource_id_route_and_returns_no_content()
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+        var createResponse = await client.PostAsync(
+            "/api/v1/tags",
+            JsonBody("{\"label\":\"Travel\",\"bgColorHex\":\"#ffffff\",\"fgColorHex\":\"#000000\"}"));
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        createResponse.Headers.Location.Should().Be(new Uri("http://localhost/api/v1/tags/1"));
+
+        var response = await client.DeleteAsync(createResponse.Headers.Location);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    private static StringContent JsonBody(string json) => new(json, Encoding.UTF8, "application/json");
+
+    private static async Task SeedAccount(WebApiTestFactory factory)
+    {
+        using var scope = factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<XpenseDbContext>();
+        dbContext.Accounts.Add(new Account
+        {
+            Name = "Cash",
+            AccountNumber = "1000000000",
+            Balance = 0,
+            CreatedOn = DateTime.UtcNow,
+            IsDefaultAccount = true
+        });
+        await dbContext.SaveChangesAsync();
+    }
+
+    private static async Task SeedPriority(WebApiTestFactory factory)
+    {
+        using var scope = factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<XpenseDbContext>();
+        dbContext.Priorities.Add(new Priority
+        {
+            Label = "Normal",
+            Weight = 1,
+            CreatedOn = DateTime.UtcNow
+        });
+        await dbContext.SaveChangesAsync();
+    }
+}

--- a/src/Xpense/Xpense.Tests/Integration/V1RouteContractTests.cs
+++ b/src/Xpense/Xpense.Tests/Integration/V1RouteContractTests.cs
@@ -1,0 +1,21 @@
+using System.Net;
+using FluentAssertions;
+using NUnit.Framework;
+using Xpense.Tests.Infrastructure;
+
+namespace Xpense.Tests.Integration;
+
+[TestFixture]
+public class V1RouteContractTests
+{
+    [Test]
+    public async Task GetAccounts_uses_the_v1_plural_resource_route()
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/accounts");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/src/Xpense/Xpense.Tests/Xpense.Tests.csproj
+++ b/src/Xpense/Xpense.Tests/Xpense.Tests.csproj
@@ -12,6 +12,8 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.DependencyValidation.Analyzers" Version="0.11.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="Moq.EntityFrameworkCore" Version="7.0.0.2" />


### PR DESCRIPTION
## What changed
- Adds the API v1 design and implementation plan.
- Introduces isolated SQLite-backed integration testing.
- Migrates accounts, categories, tags, and merchants to plural `/api/v1` resource routes.

## Why
This establishes the stable, directly consumable resource contract that later MCP-facing workflows need.

## Validation
- Serial .NET test suite passed before the branch split.

## Review order
Review this first; the transaction and analytics PRs use this branch as their base.