### PR TITLE
feat: add unified API v1 transactions

### DIFF
--- a/src/Xpense/Xpense.API/Controllers/TransactionController.cs
+++ b/src/Xpense/Xpense.API/Controllers/TransactionController.cs
@@ -20,6 +20,7 @@ public class TransactionController(
     WithdrawTransactionUseCase withdrawTransactionUseCase,
     GetAllTransactionsUseCase getAllTransactionsUseCase,
     GetAllTransactionsForAccountNumberUseCase getAllTransactionsForAccountNumberUseCase,
+    GetTransactionByIdUseCase getTransactionByIdUseCase,
     FilterTransactionsUseCase filterTransactionsUseCase,
     ILogger logger)
     : XpenseController
@@ -119,6 +120,22 @@ public class TransactionController(
     {
         var result = await filterTransactionsUseCase.Execute(FilterQuery.Of(page, size, date));
         return Ok(result, TransactionResponse.Of);
+    }
+
+    [HttpGet("/api/v1/transactions/{id:int}", Name = "Get V1 Transaction By Id")]
+    public async Task<IActionResult> GetV1ById(int id)
+    {
+        var transaction = await getTransactionByIdUseCase.Execute(id);
+        return transaction is null
+            ? new NotFoundResult()
+            : new OkObjectResult(V1TransactionResponse.From(transaction));
+    }
+
+    [HttpGet("/api/v1/transactions", Name = "Get V1 Transactions")]
+    public async Task<IActionResult> GetV1Page([FromQuery] int page, [FromQuery] int pageSize)
+    {
+        var result = await filterTransactionsUseCase.Execute(FilterQuery.Of(page, pageSize));
+        return new OkObjectResult(V1TransactionPageResponse.From(result));
     }
 
     [HttpPost("transfer")]

--- a/src/Xpense/Xpense.API/Controllers/TransactionController.cs
+++ b/src/Xpense/Xpense.API/Controllers/TransactionController.cs
@@ -1,12 +1,10 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Serilog;
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Xpense.API.Helpers;
 using Xpense.API.Models.Requests;
 using Xpense.API.Models.Responses;
-using Xpense.Services.Exceptions;
 using Xpense.Services.Features.Transactions.UseCases;
 using Xpense.Services.Models;
 
@@ -14,115 +12,53 @@ namespace Xpense.API.Controllers;
 
 [ApiController]
 [ApiVersion("1.0")]
-[Route("api/transaction")]
+[Route("api/v1/transactions")]
 public class TransactionController(
     DepositTransactionUseCase depositTransactionUseCase,
     WithdrawTransactionUseCase withdrawTransactionUseCase,
-    GetAllTransactionsUseCase getAllTransactionsUseCase,
-    GetAllTransactionsForAccountNumberUseCase getAllTransactionsForAccountNumberUseCase,
     GetTransactionByIdUseCase getTransactionByIdUseCase,
-    FilterTransactionsUseCase filterTransactionsUseCase,
-    ILogger logger)
+    FilterTransactionsUseCase filterTransactionsUseCase)
     : XpenseController
 {
-    [HttpPost("deposit")]
-    [ProducesResponseType(typeof(TransactionResponse), 200)]
-    public async Task<IActionResult> Income([FromBody] DepositTransactionRequest request)
+    [HttpPost]
+    [ProducesResponseType(typeof(V1TransactionResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Create([FromBody] CreateTransactionRequest request)
     {
-        try
+        if (!request.TryGetKind(out var kind))
         {
-            var transaction = await depositTransactionUseCase.Handle(request.ToCommand());
-            return Ok(TransactionResponse.Of(transaction));
+            ModelState.AddModelError("type", "The type must be either 'income' or 'expense'.");
         }
-        catch (AccountNotFoundException exception)
+
+        if (request.Amount is null)
         {
-            logger.Warning(exception, exception.Message);
-            return BadRequest(exception.Message);
+            ModelState.AddModelError("amount", "The amount is required.");
         }
-        catch (DefaultAccountNotFoundException exception)
+        else
         {
-            logger.Warning(exception, exception.Message);
-            return BadRequest(exception.Message);
+            if (request.Amount.Cents <= 0)
+                ModelState.AddModelError("amount.cents", "The amount in cents must be positive.");
+
+            if (!request.TryGetCurrency(out _))
+                ModelState.AddModelError("amount.currency", "The currency must be a supported currency name.");
         }
-        catch (CategoryNotFoundException exception)
+
+        if (!ModelState.IsValid)
         {
-            logger.Warning(exception, exception.Message);
-            return BadRequest(exception.Message);
+            return ValidationProblem(ModelState);
         }
-        catch (MerchantNotFoundException exception)
+
+        var transaction = kind switch
         {
-            logger.Warning(exception, exception.Message);
-            return BadRequest(exception.Message);
-        }
-        catch (DepositCreationFailedException exception)
-        {
-            logger.Error(exception, exception.Message);
-            return Problem(exception.Message);
-        }
+            TransactionKind.Income => await depositTransactionUseCase.Handle(request.ToDepositCommand()),
+            TransactionKind.Expense => await withdrawTransactionUseCase.Handle(request.ToWithdrawCommand()),
+            _ => throw new InvalidOperationException("The transaction kind was validated before dispatch.")
+        };
+
+        return CreatedAtAction(nameof(GetV1ById), new { id = transaction.Id }, V1TransactionResponse.From(transaction));
     }
 
-    [HttpPost("withdraw")]
-    [ProducesResponseType(typeof(TransactionResponse), 200)]
-    public async Task<IActionResult> Withdraw([FromBody] WithdrawTransactionRequest request)
-    {
-        try
-        {
-            var transaction = await withdrawTransactionUseCase.Handle(request.ToCommand());
-            return Ok(TransactionResponse.Of(transaction));
-        }
-        catch (AccountNotFoundException exception)
-        {
-            logger.Warning(exception, exception.Message);
-            return NotFound(exception.Message);
-        }
-        catch (CategoryNotFoundException exception)
-        {
-            logger.Warning(exception, exception.Message);
-            return NotFound(exception.Message);
-        }
-        catch (DefaultAccountNotFoundException exception)
-        {
-            logger.Warning(exception, exception.Message);
-            return BadRequest(exception.Message);
-        }
-        catch (WithdrawCreationFailedException exception)
-        {
-            logger.Error(exception, exception.Message);
-            return Problem(exception.Message);
-        }
-    }
-
-    [HttpGet("{accountNumber}", Name = "Get All Transactions for account")]
-    public async Task<IActionResult> GetAll(string accountNumber)
-    {
-        try
-        {
-            var transactions = await getAllTransactionsForAccountNumberUseCase.Execute(accountNumber);
-            return Ok(transactions.Select(TransactionResponse.Of));
-        }
-        catch (AccountNotFoundException exception)
-        {
-            logger.Warning(exception, exception.Message);
-            return NotFound(exception.Message);
-        }
-    }
-
-    [HttpGet("", Name = "Get All Transactions")]
-    public async Task<IActionResult> GetAll()
-    {
-
-        var transactions = await getAllTransactionsUseCase.Execute();
-        return Ok(transactions.Select(TransactionResponse.Of));
-    }
-
-    [HttpGet("filter", Name = "Filter transactions")]
-    public async Task<IActionResult> Filter([FromQuery] int page, [FromQuery] int size, [FromQuery] long? date = null)
-    {
-        var result = await filterTransactionsUseCase.Execute(FilterQuery.Of(page, size, date));
-        return Ok(result, TransactionResponse.Of);
-    }
-
-    [HttpGet("/api/v1/transactions/{id:int}", Name = "Get V1 Transaction By Id")]
+    [HttpGet("{id:int}", Name = "Get V1 Transaction By Id")]
     public async Task<IActionResult> GetV1ById(int id)
     {
         var transaction = await getTransactionByIdUseCase.Execute(id);
@@ -131,16 +67,11 @@ public class TransactionController(
             : new OkObjectResult(V1TransactionResponse.From(transaction));
     }
 
-    [HttpGet("/api/v1/transactions", Name = "Get V1 Transactions")]
+    [HttpGet(Name = "Get V1 Transactions")]
     public async Task<IActionResult> GetV1Page([FromQuery] int page, [FromQuery] int pageSize)
     {
         var result = await filterTransactionsUseCase.Execute(FilterQuery.Of(page, pageSize));
         return new OkObjectResult(V1TransactionPageResponse.From(result));
     }
 
-    [HttpPost("transfer")]
-    public Task<IActionResult> Transfer([FromBody] TransferTransactionRequest request)
-    {
-        throw new NotImplementedException();
-    }
 }

--- a/src/Xpense/Xpense.API/Extensions.cs/IoC.cs
+++ b/src/Xpense/Xpense.API/Extensions.cs/IoC.cs
@@ -84,6 +84,7 @@ namespace Xpense.API.Extensions.cs
         public static void AddUseCases(this IServiceCollection services)
         {
             services.AddScoped<GetAccountByNumberUseCase>();
+            services.AddScoped<GetAccountByIdUseCase>();
             services.AddScoped<GetAllAccountsUseCase>();
             services.AddScoped<CreateAccountUseCase>();
             services.AddScoped<DeleteAccountUseCase>();
@@ -107,6 +108,7 @@ namespace Xpense.API.Extensions.cs
             services.AddScoped<WithdrawTransactionUseCase>();
             services.AddScoped<GetAllTransactionsForAccountNumberUseCase>();
             services.AddScoped<GetAllTransactionsUseCase>();
+            services.AddScoped<GetTransactionByIdUseCase>();
             services.AddScoped<FilterTransactionsUseCase>();
 
             services.AddScoped<GetExpensesByCategoryUseCase>();

--- a/src/Xpense/Xpense.API/Models/Requests/CreateTransactionRequest.cs
+++ b/src/Xpense/Xpense.API/Models/Requests/CreateTransactionRequest.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Xpense.Services.Enums;
+using Xpense.Services.Features.Transactions.Commands;
+using Xpense.Services.ValueObjects;
+using ServiceMerchant = Xpense.Services.Models.Merchant;
+using ServiceTag = Xpense.Services.Models.Tag;
+
+namespace Xpense.API.Models.Requests;
+
+public enum TransactionKind
+{
+    Income,
+    Expense
+}
+
+public sealed class CreateTransactionRequest
+{
+    [Required]
+    public string Type { get; init; } = null!;
+
+    [Required]
+    public TransactionMoneyRequest Amount { get; init; } = null!;
+
+    public string? AccountNumber { get; init; }
+
+    [Range(1, int.MaxValue)]
+    public int CategoryId { get; init; }
+
+    [Required]
+    public TransactionMerchantRequest Merchant { get; init; } = null!;
+
+    public IReadOnlyList<TransactionTagRequest>? Tags { get; init; }
+
+    public DateTimeOffset? OccurredAt { get; init; }
+
+    public bool TryGetKind(out TransactionKind kind)
+    {
+        if (string.Equals(Type, "income", StringComparison.OrdinalIgnoreCase))
+        {
+            kind = TransactionKind.Income;
+            return true;
+        }
+
+        if (string.Equals(Type, "expense", StringComparison.OrdinalIgnoreCase))
+        {
+            kind = TransactionKind.Expense;
+            return true;
+        }
+
+        kind = default;
+        return false;
+    }
+
+    public bool TryGetCurrency(out Currency currency)
+    {
+        currency = default;
+        return Amount is not null
+            && !string.IsNullOrWhiteSpace(Amount.Currency)
+            && Enum.GetNames<Currency>().Any(name => string.Equals(name, Amount.Currency, StringComparison.OrdinalIgnoreCase))
+            && Enum.TryParse(Amount.Currency, true, out currency);
+    }
+
+    public DepositTransactionCommand ToDepositCommand() => new(
+        ToMoney(),
+        AccountNumber,
+        CategoryId,
+        ToMerchant(),
+        ToTags(),
+        OccurredAt?.ToUnixTimeSeconds());
+
+    public WithdrawTransactionCommand ToWithdrawCommand() => new(
+        ToMoney(),
+        AccountNumber,
+        CategoryId,
+        ToMerchant(),
+        ToTags(),
+        OccurredAt?.ToUnixTimeSeconds());
+
+    private Money ToMoney()
+    {
+        if (!TryGetCurrency(out var currency))
+            throw new InvalidOperationException("The currency must be a supported currency name.");
+
+        return Money.OfCents(Amount.Cents, currency);
+    }
+
+    private ServiceMerchant ToMerchant() => new()
+    {
+        Id = Merchant.Id,
+        Label = Merchant.Label,
+        Create = Merchant.Create
+    };
+
+    private ServiceTag[]? ToTags() => Tags?.Select(tag => new ServiceTag
+    {
+        Id = tag.Id,
+        Label = tag.Label,
+        Create = tag.Create
+    }).ToArray();
+}
+
+public sealed record TransactionMoneyRequest(long Cents, string Currency);
+
+public sealed record TransactionMerchantRequest(int? Id, string Label, bool Create);
+
+public sealed record TransactionTagRequest(int? Id, string Label, bool Create);

--- a/src/Xpense/Xpense.API/Models/Responses/V1TransactionResponse.cs
+++ b/src/Xpense/Xpense.API/Models/Responses/V1TransactionResponse.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xpense.Services.Entities;
+using Xpense.Services.Enums;
+using Xpense.Services.Models;
+
+namespace Xpense.API.Models.Responses;
+
+public sealed record V1TransactionResponse(
+    int Id,
+    string Type,
+    V1TransactionMoneyResponse Amount,
+    int? AccountId,
+    int CategoryId,
+    V1TransactionOptionResponse Merchant,
+    IReadOnlyList<V1TransactionOptionResponse> Tags,
+    string OccurredAt,
+    string? UpdatedAt)
+{
+    public static V1TransactionResponse From(Transaction transaction)
+    {
+        return new V1TransactionResponse(
+            transaction.Id,
+            transaction.TransactionType switch
+            {
+                TransactionType.Credit => "income",
+                TransactionType.Debit => "expense",
+                _ => transaction.TransactionType.ToString().ToLowerInvariant()
+            },
+            new V1TransactionMoneyResponse(transaction.Amount, transaction.Currency.ToString()),
+            transaction.AccountId,
+            transaction.CategoryId,
+            new V1TransactionOptionResponse(transaction.Merchant.Id, transaction.Merchant.Label),
+            transaction.Tags?.Select(tag => new V1TransactionOptionResponse(tag.Id, tag.Label)).ToArray() ?? [],
+            new DateTimeOffset(transaction.CreatedOn).ToUniversalTime().ToString("O"),
+            transaction.LastUpdated is null ? null : new DateTimeOffset(transaction.LastUpdated.Value).ToUniversalTime().ToString("O"));
+    }
+}
+
+public sealed record V1TransactionMoneyResponse(long Cents, string Currency);
+
+public sealed record V1TransactionOptionResponse(int Id, string Label);
+
+public sealed record V1TransactionPageResponse(
+    IReadOnlyList<V1TransactionResponse> Items,
+    int Page,
+    int PageSize,
+    int TotalItems,
+    int TotalPages)
+{
+    public static V1TransactionPageResponse From(PaginatedResult<Transaction> result)
+    {
+        return new V1TransactionPageResponse(
+            result.Data.Select(V1TransactionResponse.From).ToArray(),
+            result.Page,
+            result.Size,
+            result.TotalItems,
+            result.Pages);
+    }
+}

--- a/src/Xpense/Xpense.Persistence/Repositories/TransactionRepository.cs
+++ b/src/Xpense/Xpense.Persistence/Repositories/TransactionRepository.cs
@@ -28,10 +28,15 @@ public class TransactionRepository(XpenseDbContext dbContext)
         return transactions;
     }
 
+    public async Task<Transaction?> GetByIdWithDetails(int id)
+    {
+        return await GetBaseQuery().SingleOrDefaultAsync(transaction => transaction.Id == id);
+    }
+
     public async Task<PaginatedResult<Transaction>> Filter(int page, int pageSize, long? date = null)
     {
         if (page <= 0 || pageSize <= 0)
-            return PaginatedResult<Transaction>.FromResult(0, 0, 0, Enumerable.Empty<Transaction>());
+            return PaginatedResult<Transaction>.FromResult(0, 0, 0, 0, Enumerable.Empty<Transaction>());
 
         var query = GetBaseQuery();
         if (date.HasValue)
@@ -39,11 +44,12 @@ public class TransactionRepository(XpenseDbContext dbContext)
             var dateTime = date.ToDateTime();
             query = query.Where(t => t.CreatedOn.Date == dateTime!.Value.Date); // TODO: match the date only
         }
-        var pages = query.Count() / pageSize + (query.Count() % pageSize > 0 ? 1 : 0);
+        var totalItems = await query.CountAsync();
+        var pages = totalItems / pageSize + (totalItems % pageSize > 0 ? 1 : 0);
         var result = await query.OrderByDescending(s => s.CreatedOn).Skip(pageSize * (page - 1))
             .Take(pageSize).ToListAsync();
 
-        return PaginatedResult<Transaction>.FromResult(page, pageSize, pages, result);
+        return PaginatedResult<Transaction>.FromResult(page, pageSize, pages, totalItems, result);
     }
 
     private IQueryable<Transaction> GetBaseQuery()

--- a/src/Xpense/Xpense.Services/Abstract/Persistence/ITransactionRepository.cs
+++ b/src/Xpense/Xpense.Services/Abstract/Persistence/ITransactionRepository.cs
@@ -8,5 +8,6 @@ public interface ITransactionRepository : IRepository<Transaction>
 {
     Task<IEnumerable<Transaction>> GetAllTransactions(Account account);
     Task<IReadOnlyCollection<Transaction>> GetAllTransactions(long? date = null);
+    Task<Transaction?> GetByIdWithDetails(int id);
     Task<PaginatedResult<Transaction>> Filter(int page, int pageSize, long? date = null);
 }

--- a/src/Xpense/Xpense.Services/Features/Transactions/UseCases/GetTransactionByIdUseCase.cs
+++ b/src/Xpense/Xpense.Services/Features/Transactions/UseCases/GetTransactionByIdUseCase.cs
@@ -1,0 +1,12 @@
+using Xpense.Services.Abstract.Persistence;
+using Xpense.Services.Entities;
+
+namespace Xpense.Services.Features.Transactions.UseCases;
+
+public class GetTransactionByIdUseCase(ITransactionRepository repository)
+{
+    public Task<Transaction?> Execute(int id, CancellationToken cancellationToken = default)
+    {
+        return repository.GetByIdWithDetails(id);
+    }
+}

--- a/src/Xpense/Xpense.Services/Models/PaginatedResult.cs
+++ b/src/Xpense/Xpense.Services/Models/PaginatedResult.cs
@@ -2,14 +2,15 @@
 
 namespace Xpense.Services.Models
 {
-    public class PaginatedResult<T>(int page, int size, int pages, IEnumerable<T> data) where T : BaseEntity
+    public class PaginatedResult<T>(int page, int size, int pages, int totalItems, IEnumerable<T> data) where T : BaseEntity
     {
         public int Pages { get; set; } = pages;
         public int Size { get; set; } = size;
         public int Page { get; set; } = page;
+        public int TotalItems { get; set; } = totalItems;
         public IEnumerable<T> Data { get; set; } = data;
 
-        public static PaginatedResult<T> FromResult(int page, int size, int pages, IEnumerable<T> data) =>
-            new(page, size, pages, data);
+        public static PaginatedResult<T> FromResult(int page, int size, int pages, int totalItems, IEnumerable<T> data) =>
+            new(page, size, pages, totalItems, data);
     }
 }

--- a/src/Xpense/Xpense.Services/ValueObjects/Money.cs
+++ b/src/Xpense/Xpense.Services/ValueObjects/Money.cs
@@ -17,7 +17,7 @@ namespace Xpense.Services.ValueObjects
 
         public decimal ToSingle()
         {
-            return this.Cents / 100;
+            return this.Cents / 100m;
         }
 
         public static Money operator +(Money lhs, Money rhs)

--- a/src/Xpense/Xpense.Tests/Integration/V1TransactionEndpointTests.cs
+++ b/src/Xpense/Xpense.Tests/Integration/V1TransactionEndpointTests.cs
@@ -1,0 +1,169 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xpense.Persistence;
+using Xpense.Services.Entities;
+using Xpense.Tests.Infrastructure;
+
+namespace Xpense.Tests.Integration;
+
+[TestFixture]
+public class V1TransactionEndpointTests
+{
+    [Test]
+    public async Task Post_income_creates_a_direct_v1_resource_and_uses_the_get_by_id_location()
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+        var seeded = await SeedAccountAndCategory(factory, 0m);
+        var occurredAt = new DateTimeOffset(2026, 7, 26, 9, 30, 0, TimeSpan.Zero);
+
+        var response = await client.PostAsJsonAsync("/api/v1/transactions", new
+        {
+            type = "income",
+            amount = new { cents = 1234, currency = "EUR" },
+            accountNumber = seeded.AccountNumber,
+            categoryId = seeded.CategoryId,
+            merchant = new { label = "Employer", create = true },
+            tags = new[] { new { label = "salary", create = true } },
+            occurredAt
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.Location.Should().NotBeNull();
+        response.Headers.Location!.ToString().Should().MatchRegex("/api/v1/transactions/[1-9][0-9]*$");
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var transaction = document.RootElement;
+        transaction.TryGetProperty("data", out _).Should().BeFalse();
+        transaction.GetProperty("type").GetString().Should().Be("income");
+        transaction.GetProperty("amount").GetProperty("cents").GetInt64().Should().Be(1234);
+        transaction.GetProperty("amount").GetProperty("currency").GetString().Should().Be("EUR");
+        transaction.GetProperty("accountId").GetInt32().Should().Be(seeded.AccountId);
+        transaction.GetProperty("categoryId").GetInt32().Should().Be(seeded.CategoryId);
+        transaction.GetProperty("merchant").GetProperty("label").GetString().Should().Be("Employer");
+        transaction.GetProperty("tags").GetArrayLength().Should().Be(1);
+        transaction.GetProperty("occurredAt").GetDateTimeOffset().Should().Be(occurredAt);
+
+        var createdId = transaction.GetProperty("id").GetInt32();
+        var getCreatedResponse = await client.GetAsync(response.Headers.Location);
+        getCreatedResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var getCreatedDocument = JsonDocument.Parse(await getCreatedResponse.Content.ReadAsStringAsync());
+        getCreatedDocument.RootElement.GetProperty("id").GetInt32().Should().Be(createdId);
+
+        (await GetAccountBalance(factory, seeded.AccountId)).Should().Be(12.34m);
+    }
+
+    [Test]
+    public async Task Post_expense_creates_a_direct_v1_resource_and_debits_exact_cents()
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+        var seeded = await SeedAccountAndCategory(factory, 20m);
+
+        var response = await client.PostAsJsonAsync("/api/v1/transactions", new
+        {
+            type = "expense",
+            amount = new { cents = 99, currency = "USD" },
+            accountNumber = seeded.AccountNumber,
+            categoryId = seeded.CategoryId,
+            merchant = new { label = "Coffee Shop", create = true }
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var transaction = document.RootElement;
+        transaction.GetProperty("type").GetString().Should().Be("expense");
+        transaction.GetProperty("amount").GetProperty("cents").GetInt64().Should().Be(99);
+        transaction.GetProperty("amount").GetProperty("currency").GetString().Should().Be("USD");
+        transaction.GetProperty("updatedAt").ValueKind.Should().Be(JsonValueKind.Null);
+
+        (await GetAccountBalance(factory, seeded.AccountId)).Should().Be(19.01m);
+    }
+
+    [TestCase("transfer")]
+    [TestCase("refund")]
+    public async Task Post_with_an_unsupported_type_returns_a_validation_problem(string type)
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/v1/transactions", new
+        {
+            type,
+            amount = new { cents = 1234, currency = "EUR" },
+            categoryId = 1,
+            merchant = new { label = "Employer", create = true }
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/problem+json");
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("errors").TryGetProperty("type", out _).Should().BeTrue();
+    }
+
+    [TestCase(0, "EUR")]
+    [TestCase(1234, "0")]
+    [TestCase(1234, "GBP")]
+    public async Task Post_with_an_invalid_amount_returns_a_validation_problem(long cents, string currency)
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/v1/transactions", new
+        {
+            type = "income",
+            amount = new { cents, currency },
+            categoryId = 1,
+            merchant = new { label = "Employer", create = true }
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/problem+json");
+    }
+
+    [TestCase("/api/transaction/deposit")]
+    [TestCase("/api/transaction/withdraw")]
+    [TestCase("/api/transaction/transfer")]
+    [TestCase("/api/v1/transfers")]
+    public async Task Removed_or_unimplemented_transaction_routes_return_not_found(string path)
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync(path, JsonContent.Create(new { }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    private static async Task<SeededAccountAndCategory> SeedAccountAndCategory(WebApiTestFactory factory, decimal balance)
+    {
+        using var scope = factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<XpenseDbContext>();
+        var priority = new Priority { Label = "Normal", Weight = 1, CreatedOn = DateTime.UtcNow };
+        var account = new Account
+        {
+            Name = "Cash",
+            AccountNumber = "1000000000",
+            Balance = balance,
+            CreatedOn = DateTime.UtcNow,
+            IsDefaultAccount = true
+        };
+        var category = new Category { Label = "Food", Priority = priority, CreatedOn = DateTime.UtcNow };
+        dbContext.AddRange(priority, account, category);
+        await dbContext.SaveChangesAsync();
+
+        return new SeededAccountAndCategory(account.Id, account.AccountNumber, category.Id);
+    }
+
+    private static async Task<decimal> GetAccountBalance(WebApiTestFactory factory, int accountId)
+    {
+        using var scope = factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<XpenseDbContext>();
+        return await dbContext.Accounts.AsNoTracking().Where(account => account.Id == accountId).Select(account => account.Balance).SingleAsync();
+    }
+
+    private sealed record SeededAccountAndCategory(int AccountId, string AccountNumber, int CategoryId);
+}

--- a/src/Xpense/Xpense.Tests/Integration/V1TransactionReadTests.cs
+++ b/src/Xpense/Xpense.Tests/Integration/V1TransactionReadTests.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xpense.Persistence;
+using Xpense.Services.Entities;
+using Xpense.Services.Enums;
+using Xpense.Tests.Infrastructure;
+
+namespace Xpense.Tests.Integration;
+
+[TestFixture]
+public class V1TransactionReadTests
+{
+    [Test]
+    public async Task Get_transaction_by_id_returns_the_direct_v1_transaction_resource()
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+        var seeded = await SeedTransactions(factory);
+
+        var response = await client.GetAsync($"/api/v1/transactions/{seeded.LatestTransactionId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var transaction = document.RootElement;
+        transaction.TryGetProperty("data", out _).Should().BeFalse();
+        transaction.GetProperty("id").GetInt32().Should().Be(seeded.LatestTransactionId);
+        transaction.GetProperty("type").GetString().Should().Be("income");
+        transaction.GetProperty("amount").GetProperty("cents").GetInt64().Should().Be(1234);
+        transaction.GetProperty("amount").GetProperty("currency").GetString().Should().Be("EUR");
+        transaction.GetProperty("accountId").GetInt32().Should().Be(seeded.AccountId);
+        transaction.GetProperty("categoryId").GetInt32().Should().Be(seeded.CategoryId);
+        transaction.GetProperty("merchant").GetProperty("id").GetInt32().Should().Be(seeded.MerchantId);
+        transaction.GetProperty("merchant").GetProperty("label").GetString().Should().Be("Grocer");
+        transaction.GetProperty("tags").GetArrayLength().Should().Be(0);
+        transaction.GetProperty("occurredAt").GetDateTimeOffset().Should().Be(new DateTimeOffset(2026, 7, 26, 12, 0, 0, TimeSpan.Zero));
+        transaction.GetProperty("updatedAt").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Test]
+    public async Task Get_transactions_returns_truthful_total_items_for_the_requested_page()
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+        var seeded = await SeedTransactions(factory);
+
+        var response = await client.GetAsync("/api/v1/transactions?page=2&pageSize=2");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var page = document.RootElement;
+        page.TryGetProperty("data", out _).Should().BeFalse();
+        page.GetProperty("page").GetInt32().Should().Be(2);
+        page.GetProperty("pageSize").GetInt32().Should().Be(2);
+        page.GetProperty("totalItems").GetInt32().Should().Be(3);
+        page.GetProperty("totalPages").GetInt32().Should().Be(2);
+        var items = page.GetProperty("items");
+        items.GetArrayLength().Should().Be(1);
+        items[0].GetProperty("id").GetInt32().Should().Be(seeded.OldestTransactionId);
+    }
+
+    private static async Task<SeededTransactions> SeedTransactions(WebApiTestFactory factory)
+    {
+        using var scope = factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<XpenseDbContext>();
+        var priority = new Priority { Label = "Normal", Weight = 1, CreatedOn = DateTime.UtcNow };
+        var account = new Account
+        {
+            Name = "Cash",
+            AccountNumber = "1000000000",
+            Balance = 0,
+            CreatedOn = DateTime.UtcNow,
+            IsDefaultAccount = true
+        };
+        var category = new Category { Label = "Food", Priority = priority, CreatedOn = DateTime.UtcNow };
+        var merchant = new Merchant { Label = "Grocer", CreatedOn = DateTime.UtcNow };
+        dbContext.AddRange(priority, account, category, merchant);
+        await dbContext.SaveChangesAsync();
+
+        var oldest = NewTransaction(500, TransactionType.Debit, new DateTimeOffset(2026, 7, 26, 10, 0, 0, TimeSpan.Zero), account, category, merchant);
+        var middle = NewTransaction(999, TransactionType.Debit, new DateTimeOffset(2026, 7, 26, 11, 0, 0, TimeSpan.Zero), account, category, merchant);
+        var latest = NewTransaction(1234, TransactionType.Credit, new DateTimeOffset(2026, 7, 26, 12, 0, 0, TimeSpan.Zero), account, category, merchant);
+        dbContext.Transactions.AddRange(oldest, middle, latest);
+        await dbContext.SaveChangesAsync();
+
+        return new SeededTransactions(latest.Id, oldest.Id, account.Id, category.Id, merchant.Id);
+    }
+
+    private static Transaction NewTransaction(long amount, TransactionType type, DateTimeOffset occurredAt, Account account, Category category, Merchant merchant) => new()
+    {
+        Amount = amount,
+        Currency = Currency.EUR,
+        TransactionType = type,
+        Account = account,
+        Category = category,
+        Merchant = merchant,
+        Tags = [],
+        CreatedOn = occurredAt.LocalDateTime
+    };
+
+    private sealed record SeededTransactions(int LatestTransactionId, int OldestTransactionId, int AccountId, int CategoryId, int MerchantId);
+}

--- a/src/Xpense/Xpense.Tests/Unit/CreateTransactionRequestTests.cs
+++ b/src/Xpense/Xpense.Tests/Unit/CreateTransactionRequestTests.cs
@@ -1,0 +1,76 @@
+using FluentAssertions;
+using Xpense.API.Models.Requests;
+using Xpense.Services.Enums;
+
+namespace Xpense.Tests.Unit;
+
+[TestFixture]
+public class CreateTransactionRequestTests
+{
+    [Test]
+    public void Income_maps_public_values_to_a_deposit_command()
+    {
+        var occurredAt = new DateTimeOffset(2026, 7, 26, 9, 30, 0, TimeSpan.Zero);
+        var request = new CreateTransactionRequest
+        {
+            Type = "income",
+            Amount = new TransactionMoneyRequest(1234, "EUR"),
+            AccountNumber = "1234567890",
+            CategoryId = 7,
+            Merchant = new TransactionMerchantRequest(4, "Employer", false),
+            Tags = [new TransactionTagRequest(2, "salary", false)],
+            OccurredAt = occurredAt
+        };
+
+        request.TryGetKind(out var kind).Should().BeTrue();
+        kind.Should().Be(TransactionKind.Income);
+
+        var command = request.ToDepositCommand();
+        command.Amount.Cents.Should().Be(1234);
+        command.Amount.Currency.Should().Be(Currency.EUR);
+        command.AccountNumber.Should().Be("1234567890");
+        command.CategoryId.Should().Be(7);
+        command.Merchant.Id.Should().Be(4);
+        command.Merchant.Label.Should().Be("Employer");
+        command.Merchant.Create.Should().BeFalse();
+        command.Tags.Should().ContainSingle();
+        command.Tags![0].Id.Should().Be(2);
+        command.Tags[0].Label.Should().Be("salary");
+        command.CreatedOn.Should().Be(occurredAt.ToUnixTimeSeconds());
+    }
+
+    [Test]
+    public void Expense_maps_optional_account_and_timestamp_to_a_withdraw_command()
+    {
+        var request = new CreateTransactionRequest
+        {
+            Type = "expense",
+            Amount = new TransactionMoneyRequest(99, "USD"),
+            CategoryId = 3,
+            Merchant = new TransactionMerchantRequest(null, "Coffee Shop", true)
+        };
+
+        request.TryGetKind(out var kind).Should().BeTrue();
+        kind.Should().Be(TransactionKind.Expense);
+
+        var command = request.ToWithdrawCommand();
+        command.Amount.Cents.Should().Be(99);
+        command.Amount.Currency.Should().Be(Currency.USD);
+        command.AccountNumber.Should().BeNull();
+        command.CategoryId.Should().Be(3);
+        command.Merchant.Id.Should().BeNull();
+        command.Merchant.Label.Should().Be("Coffee Shop");
+        command.Merchant.Create.Should().BeTrue();
+        command.Tags.Should().BeNull();
+        command.CreatedOn.Should().BeNull();
+    }
+
+    [TestCase("transfer")]
+    [TestCase("refund")]
+    public void Unsupported_type_does_not_classify_as_a_transaction_kind(string type)
+    {
+        var request = new CreateTransactionRequest { Type = type };
+
+        request.TryGetKind(out _).Should().BeFalse();
+    }
+}

--- a/src/Xpense/Xpense.Tests/Unit/MoneyTests.cs
+++ b/src/Xpense/Xpense.Tests/Unit/MoneyTests.cs
@@ -1,0 +1,14 @@
+using FluentAssertions;
+using Xpense.Services.ValueObjects;
+
+namespace Xpense.Tests.Unit;
+
+[TestFixture]
+public class MoneyTests
+{
+    [Test]
+    public void ToSingle_converts_cents_to_decimal_currency_units()
+    {
+        Money.OfCents(1234).ToSingle().Should().Be(12.34m);
+    }
+}


### PR DESCRIPTION
## What changed
- Fixes cent precision and adds transaction read/paging foundations.
- Adds unified `POST /api/v1/transactions` for income and expense.
- Removes legacy transaction routes and validates the returned Location.

## Why
Makes financial transaction capture usable through one explicit v1 contract before adding transfers.

## Validation
- Transaction-focused tests passed (17/17).
- Full serial suite passed before the branch split.

## Review order
Review after the API v1 resource contract PR.