### PR TITLE
build: target .NET 10

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Restore dependencies
       run: dotnet restore $SOLUTION
     - name: Build

--- a/src/Xpense/Xpense.API/Controllers/AccountController.cs
+++ b/src/Xpense/Xpense.API/Controllers/AccountController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System.Linq;

--- a/src/Xpense/Xpense.API/Controllers/AnalyticsController.cs
+++ b/src/Xpense/Xpense.API/Controllers/AnalyticsController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;

--- a/src/Xpense/Xpense.API/Controllers/TransactionController.cs
+++ b/src/Xpense/Xpense.API/Controllers/TransactionController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System;

--- a/src/Xpense/Xpense.API/Controllers/TransferController.cs
+++ b/src/Xpense/Xpense.API/Controllers/TransferController.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Xpense.API.Models.Requests;

--- a/src/Xpense/Xpense.API/Extensions.cs/IoC.cs
+++ b/src/Xpense/Xpense.API/Extensions.cs/IoC.cs
@@ -1,10 +1,9 @@
-﻿using FluentValidation;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Versioning;
+﻿using Asp.Versioning;
+using FluentValidation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using System;
 using System.IO;
 using System.Reflection;
@@ -71,7 +70,7 @@ namespace Xpense.API.Extensions.cs
                 options.AssumeDefaultVersionWhenUnspecified = true;
                 options.ReportApiVersions = true;
                 options.ApiVersionReader = new HeaderApiVersionReader("x-api-version");
-            });
+            }).AddMvc();
         }
 
         public static void AddRepositories(this IServiceCollection services)

--- a/src/Xpense/Xpense.API/Xpense.API.csproj
+++ b/src/Xpense/Xpense.API/Xpense.API.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
-		<Nullable>disable</Nullable>
+		<TargetFramework>net10.0</TargetFramework>
+		<!-- "annotations" lets DTOs use `?` without turning on the full null-flow analysis,
+		     which the rest of this project is not yet clean under. -->
+		<Nullable>annotations</Nullable>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<!--TODO: Remove the below warning once stabilized-->
@@ -24,17 +26,15 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FluentValidation" Version="11.9.2" />
-		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.2" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.6" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
-		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.2" />
-		<PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
-		<PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.5.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
+		<!-- Asp.Versioning.Mvc replaces Microsoft.AspNetCore.Mvc.Versioning, which was
+		     deprecated and never targeted anything past net6. -->
+		<PackageReference Include="Asp.Versioning.Mvc" Version="10.0.0" />
+		<PackageReference Include="FluentValidation" Version="12.1.1" />
+		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.10" />
+		<PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Xpense/Xpense.Persistence/Xpense.Persistence.csproj
+++ b/src/Xpense/Xpense.Persistence/Xpense.Persistence.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -15,15 +15,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.10">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Xpense/Xpense.Services/Features/Transactions/UseCases/DepositTransactionUseCase.cs
+++ b/src/Xpense/Xpense.Services/Features/Transactions/UseCases/DepositTransactionUseCase.cs
@@ -31,11 +31,7 @@ public class DepositTransactionUseCase(
 
         var merchant = await merchantRepository.GetOrCreateIfMissing(command.Merchant) ?? throw new MerchantNotFoundException(command.Merchant.Label);
 
-        var tags = command.Tags != null
-            ? await command.Tags.ToAsyncEnumerable()
-                .SelectAwait(async t => await tagRepository.GetOrCreateIfMissing(t))
-                .Where(t => t != null).ToListAsync()
-            : null;
+        var tags = await ResolveTags(tagRepository, command.Tags);
 
         var transaction = new Transaction
         {
@@ -56,5 +52,26 @@ public class DepositTransactionUseCase(
             throw new DepositCreationFailedException(command.Amount.ToDecimal(), command.AccountNumber);
 
         return transaction;
+    }
+
+    /// <summary>
+    /// Resolves each requested tag, creating it when missing and dropping any that could not be
+    /// resolved. This used to run through IAsyncEnumerable over an in-memory array, which net10
+    /// no longer supports the same way -- and which was only ever a sequential loop.
+    /// </summary>
+    internal static async Task<List<Tag>?> ResolveTags(ITagRepository tagRepository, Models.Tag[]? requested)
+    {
+        if (requested is null)
+            return null;
+
+        List<Tag> tags = [];
+        foreach (var tag in requested)
+        {
+            var resolved = await tagRepository.GetOrCreateIfMissing(tag);
+            if (resolved != null)
+                tags.Add(resolved);
+        }
+
+        return tags;
     }
 }

--- a/src/Xpense/Xpense.Services/Features/Transactions/UseCases/WithdrawTransactionUseCase.cs
+++ b/src/Xpense/Xpense.Services/Features/Transactions/UseCases/WithdrawTransactionUseCase.cs
@@ -31,11 +31,7 @@ public class WithdrawTransactionUseCase(
 
         var merchant = await merchantRepository.GetOrCreateIfMissing(command.Merchant) ?? throw new MerchantNotFoundException(command.Merchant.Label);
 
-        var tags = command.Tags != null
-            ? await command.Tags.ToAsyncEnumerable()
-                .SelectAwait(async t => await tagRepository.GetOrCreateIfMissing(t))
-                .Where(t => t != null).ToListAsync()
-            : null;
+        var tags = await DepositTransactionUseCase.ResolveTags(tagRepository, command.Tags);
 
         var transaction = new Transaction
         {

--- a/src/Xpense/Xpense.Services/Xpense.Services.csproj
+++ b/src/Xpense/Xpense.Services/Xpense.Services.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -12,12 +12,7 @@
     </AdditionalFiles>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Features\Merchants\Commands\" />
-  </ItemGroup>
+  <!-- System.Linq.Async removed: net10 ships System.Linq.AsyncEnumerable in the BCL and the
+       package's extension methods now collide with it. -->
 
 </Project>

--- a/src/Xpense/Xpense.Tests/Infrastructure/WebApiTestFactory.cs
+++ b/src/Xpense/Xpense.Tests/Infrastructure/WebApiTestFactory.cs
@@ -1,9 +1,9 @@
+using System.Linq;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Xpense.Persistence;
 
@@ -18,11 +18,31 @@ public sealed class WebApiTestFactory : WebApplicationFactory<Program>
         builder.UseEnvironment("Testing");
         builder.ConfigureServices(services =>
         {
-            services.RemoveAll<DbContextOptions<XpenseDbContext>>();
-            services.RemoveAll<XpenseDbContext>();
+            RemoveProductionDbContext(services);
             connection.Open();
             services.AddDbContext<XpenseDbContext>(options => options.UseSqlite(connection));
         });
+    }
+
+    /// <summary>
+    /// AddDbContext registers more than DbContextOptions&lt;T&gt;: it also registers the
+    /// non-generic DbContextOptions and, from EF 9 onwards, IDbContextOptionsConfiguration&lt;T&gt;.
+    /// Leaving any of them behind means both SqlServer and Sqlite stay registered, which EF 10
+    /// rejects outright ("Only a single database provider can be registered").
+    /// </summary>
+    private static void RemoveProductionDbContext(IServiceCollection services)
+    {
+        var doomed = services
+            .Where(descriptor =>
+                descriptor.ServiceType == typeof(XpenseDbContext) ||
+                descriptor.ServiceType == typeof(DbContextOptions) ||
+                descriptor.ServiceType == typeof(DbContextOptions<XpenseDbContext>) ||
+                (descriptor.ServiceType.IsGenericType &&
+                 descriptor.ServiceType.GetGenericArguments().Contains(typeof(XpenseDbContext))))
+            .ToList();
+
+        foreach (var descriptor in doomed)
+            services.Remove(descriptor);
     }
 
     protected override IHost CreateHost(IHostBuilder builder)

--- a/src/Xpense/Xpense.Tests/Xpense.Tests.csproj
+++ b/src/Xpense/Xpense.Tests/Xpense.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,21 +10,22 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Pinned to 6.x on purpose: FluentAssertions 8 moved to a commercial Xceed licence.
+         6.12.0 is Apache-2.0 and runs fine on net10. -->
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.DependencyValidation.Analyzers" Version="0.11.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
-    <PackageReference Include="Moq.EntityFrameworkCore" Version="7.0.0.2" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Services\" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Moq.EntityFrameworkCore" Version="10.0.0.2" />
+    <!-- Pulled in transitively by EntityFrameworkCore.Sqlite at 2.1.11, which carries a
+         high-severity advisory (GHSA-2m69-gcr7-jv3q). Forced up to a patched build. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.11.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Retarget all four projects to `net10.0`: EF Core 10, ASP.NET Core 10, Serilog 10, Swashbuckle 10, FluentValidation 12, Test SDK 18, NUnit 4.

Migrations the upgrade forced:

- `Microsoft.AspNetCore.Mvc.Versioning` is deprecated and never targeted past net6 → `Asp.Versioning.Mvc`; MVC support is opt-in via `AddMvc()`.
- OpenAPI.NET 2.x flattened `Microsoft.OpenApi.Models` into `Microsoft.OpenApi`.
- net10 ships `System.Linq.AsyncEnumerable` in the BCL, colliding with the `System.Linq.Async` package. Dropped; the one use ran `IAsyncEnumerable` over an in-memory array, so it is a loop now.
- EF 10 rejects two registered providers outright. `WebApiTestFactory` removed `DbContextOptions<XpenseDbContext>` but not the non-generic `DbContextOptions` or EF 9's `IDbContextOptionsConfiguration<T>`, so SqlServer stayed registered alongside Sqlite and every integration test failed at host startup.

Also resolved:

- `SQLitePCLRaw.lib.e_sqlite3` arrived transitively at 2.1.11, carrying a high-severity advisory (GHSA-2m69-gcr7-jv3q). Forced to a patched 3.0.5.
- `Nullable=annotations` on Xpense.API so DTOs can use `?` without CS8632.

Warnings drop from 44 to 17. **54 passed, 2 skipped** on net10.0.

**13 files.** Stack tip — code here is byte-identical to #25.