### PR TITLE
ci: generate a code coverage report

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -33,10 +33,29 @@ jobs:
     - name: Build
       run: dotnet build $SOLUTION --no-restore
     - name: Test
-      run: dotnet test $SOLUTION --no-build --logger trx --results-directory TestResults
+      run: >
+        dotnet test $SOLUTION --no-build
+        --logger trx --results-directory TestResults
+        --collect:"XPlat Code Coverage"
+    - name: Coverage report
+      if: ${{ !cancelled() }}
+      run: |
+        dotnet tool install --global dotnet-reportgenerator-globaltool
+        export PATH="$PATH:$HOME/.dotnet/tools"
+        reportgenerator \
+          -reports:'TestResults/**/coverage.cobertura.xml' \
+          -targetdir:CoverageReport \
+          -reporttypes:'MarkdownSummaryGithub;Html'
+        cat CoverageReport/SummaryGithub.md >> "$GITHUB_STEP_SUMMARY"
     - name: Upload dotnet test results
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v4
       with:
         name: dotnet-results
         path: TestResults
+    - name: Upload coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: CoverageReport

--- a/.gitignore
+++ b/.gitignore
@@ -397,3 +397,10 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Test and coverage output, produced by the CI coverage step and by local runs
+TestResults/
+CoverageReport/
+
+# macOS
+.DS_Store


### PR DESCRIPTION
The test step now collects coverage and [ReportGenerator](https://reportgenerator.io) renders a markdown summary into `$GITHUB_STEP_SUMMARY`, so the numbers show on the run page itself instead of only inside a downloaded file.

- `dotnet test --collect:"XPlat Code Coverage"` — `coverlet.collector` was **already** referenced by `Xpense.Tests`, so no project file changes.
- `MarkdownSummaryGithub` → job summary. `Html` + raw cobertura → artifacts for line-by-line detail.
- Verified locally end to end: cobertura is produced and the summary renders.

**Reports, does not gate** — no minimum threshold. Say the word if you want one.

Also ignores `TestResults/` and `CoverageReport/`, which this step and local runs both produce, plus `.DS_Store` (untracked copies were already floating in the tree).

**2 files.** Independent of the #31–#39 stack — touches only the workflow and gitignore, so no conflict.