### PR TITLE
chore: land the reviewed #31 work on main

### DIFF
--- a/src/Xpense/Xpense.API/Controllers/AccountController.cs
+++ b/src/Xpense/Xpense.API/Controllers/AccountController.cs
@@ -19,24 +19,20 @@ namespace Xpense.API.Controllers
         CreateAccountUseCase createAccount,
         GetAllAccountsUseCase getAllAccountsAccounts,
         DeleteAccountUseCase deleteAccountUseCase,
-        GetAccountByNumberUseCase getAccountByNumberUseCase,
         UpdateAccountUseCase updateAccountUseCase,
         ILogger logger) : XpenseController
     {
         [HttpGet(
-            "{accountNumber:minlength(10):maxlength(10)}",
-            Name = "Get Account By (Account Number)"
+            "{id:int}",
+            Name = "Get Account By Id"
         )]
         [ProducesResponseType<AccountResponse>(StatusCodes.Status200OK, "application/json")]
-        public async Task<IActionResult> GetByAccountNumber(string accountNumber)
+        public async Task<IActionResult> GetById(int id)
         {
             try
             {
-                if (string.IsNullOrWhiteSpace(accountNumber) || accountNumber.Length != 10)
-                    return ValidationProblem($"Please provide a valid account accountNumber");
-
-                var account = await getAccountByNumberUseCase.Execute(accountNumber);
-                return Ok(AccountResponse.Of(account));
+                var account = await FindById(id);
+                return new OkObjectResult(AccountResponse.Of(account));
             }
             catch (AccountNotFoundException ex)
             {
@@ -48,7 +44,7 @@ namespace Xpense.API.Controllers
         public async Task<IActionResult> Get()
         {
             var accounts = await getAllAccountsAccounts.Execute();
-            return Ok(accounts.Select(AccountResponse.Of));
+            return new OkObjectResult(accounts.Select(AccountResponse.Of));
         }
 
         [HttpPost("", Name = "Create Account", Order = 1)]
@@ -57,7 +53,7 @@ namespace Xpense.API.Controllers
             try
             {
                 var createdAccount = await createAccount.Handle(request.ToCommand());
-                return Ok(AccountResponse.Of(createdAccount));
+                return CreatedAtAction(nameof(GetById), new { id = createdAccount.Id }, AccountResponse.Of(createdAccount));
             }
             catch (AccountCreationFailedException exception)
             {
@@ -67,18 +63,16 @@ namespace Xpense.API.Controllers
         }
 
         [HttpDelete(
-            "{accountNumber:minlength(10):maxlength(10)}",
-            Name = "Delete Account By Number"
+            "{id:int}",
+            Name = "Delete Account By Id"
         )]
-        public async Task<IActionResult> Delete(string number)
+        public async Task<IActionResult> Delete(int id)
         {
             try
             {
-                if (string.IsNullOrWhiteSpace(number) || number.Length != 10)
-                    return ValidationProblem($"Please provide a valid account accountNumber");
-
-                await deleteAccountUseCase.Handle(number);
-                return Ok("Account Deleted Successfully");
+                var account = await FindById(id);
+                await deleteAccountUseCase.Handle(account.AccountNumber);
+                return NoContent();
             }
             catch (AccountNotFoundException exception)
             {
@@ -92,15 +86,18 @@ namespace Xpense.API.Controllers
             }
         }
 
-        [HttpPut(Name = "Update account")]
-        public async Task<IActionResult> Update([FromBody] UpdateAccountRequest request)
+        [HttpPut("{id:int}", Name = "Update account")]
+        public async Task<IActionResult> Update(int id, [FromBody] UpdateAccountRequest request)
         {
             try
             {
                 if (request == null || !ModelState.IsValid)
                     return ValidationProblem($"Invalid Patch Request: {ModelState}");
+
+                var account = await FindById(id);
+                request.Number = account.AccountNumber;
                 var result = await updateAccountUseCase.Handle(request.ToCommand());
-                return Ok(AccountResponse.Of(result));
+                return new OkObjectResult(AccountResponse.Of(result));
             }
             catch (AccountNotFoundException exception)
             {
@@ -112,6 +109,12 @@ namespace Xpense.API.Controllers
                 logger.Warning(exception.Message);
                 return Problem(exception.Message);
             }
+        }
+
+        private async Task<Xpense.Services.Entities.Account> FindById(int id)
+        {
+            var account = (await getAllAccountsAccounts.Execute()).SingleOrDefault(account => account.Id == id);
+            return account ?? throw new AccountNotFoundException(id.ToString());
         }
     }
 }

--- a/src/Xpense/Xpense.API/Controllers/AccountController.cs
+++ b/src/Xpense/Xpense.API/Controllers/AccountController.cs
@@ -18,6 +18,7 @@ namespace Xpense.API.Controllers
     public class AccountController(
         CreateAccountUseCase createAccount,
         GetAllAccountsUseCase getAllAccountsAccounts,
+        GetAccountByIdUseCase getAccountByIdUseCase,
         DeleteAccountUseCase deleteAccountUseCase,
         UpdateAccountUseCase updateAccountUseCase,
         ILogger logger) : XpenseController
@@ -31,7 +32,7 @@ namespace Xpense.API.Controllers
         {
             try
             {
-                var account = await FindById(id);
+                var account = await getAccountByIdUseCase.Execute(id);
                 return new OkObjectResult(AccountResponse.Of(account));
             }
             catch (AccountNotFoundException ex)
@@ -70,8 +71,7 @@ namespace Xpense.API.Controllers
         {
             try
             {
-                var account = await FindById(id);
-                await deleteAccountUseCase.Handle(account.AccountNumber);
+                await deleteAccountUseCase.Handle(id);
                 return NoContent();
             }
             catch (AccountNotFoundException exception)
@@ -94,9 +94,7 @@ namespace Xpense.API.Controllers
                 if (request == null || !ModelState.IsValid)
                     return ValidationProblem($"Invalid Patch Request: {ModelState}");
 
-                var account = await FindById(id);
-                request.Number = account.AccountNumber;
-                var result = await updateAccountUseCase.Handle(request.ToCommand());
+                var result = await updateAccountUseCase.Handle(request.ToCommand(id));
                 return new OkObjectResult(AccountResponse.Of(result));
             }
             catch (AccountNotFoundException exception)
@@ -109,12 +107,6 @@ namespace Xpense.API.Controllers
                 logger.Warning(exception.Message);
                 return Problem(exception.Message);
             }
-        }
-
-        private async Task<Xpense.Services.Entities.Account> FindById(int id)
-        {
-            var account = (await getAllAccountsAccounts.Execute()).SingleOrDefault(account => account.Id == id);
-            return account ?? throw new AccountNotFoundException(id.ToString());
         }
     }
 }

--- a/src/Xpense/Xpense.API/Controllers/AccountController.cs
+++ b/src/Xpense/Xpense.API/Controllers/AccountController.cs
@@ -23,10 +23,7 @@ namespace Xpense.API.Controllers
         UpdateAccountUseCase updateAccountUseCase,
         ILogger logger) : XpenseController
     {
-        [HttpGet(
-            "{id:int}",
-            Name = "Get Account By Id"
-        )]
+        [HttpGet("{id:int}", Name = "Get Account By Id")]
         [ProducesResponseType<AccountResponse>(StatusCodes.Status200OK, "application/json")]
         public async Task<IActionResult> GetById(int id)
         {
@@ -63,10 +60,7 @@ namespace Xpense.API.Controllers
             }
         }
 
-        [HttpDelete(
-            "{id:int}",
-            Name = "Delete Account By Id"
-        )]
+        [HttpDelete("{id:int}", Name = "Delete Account By Id")]
         public async Task<IActionResult> Delete(int id)
         {
             try

--- a/src/Xpense/Xpense.API/Controllers/CategoryController.cs
+++ b/src/Xpense/Xpense.API/Controllers/CategoryController.cs
@@ -10,7 +10,7 @@ using Xpense.Services.Features.Categories.UseCases;
 
 namespace Xpense.API.Controllers
 {
-    [Route("api/category")]
+    [Route("api/v1/categories")]
     [ApiController]
     public class CategoryController(
         CreateCategoryUseCase createCategory,
@@ -25,7 +25,7 @@ namespace Xpense.API.Controllers
         public async Task<IActionResult> Get()
         {
             var categories = await getAllCategoriesUseCase.Execute();
-            return Ok(categories.Select(CategoryResponse.Of));
+            return new OkObjectResult(categories.Select(CategoryResponse.Of));
         }
 
         [HttpGet("{id:int}")]
@@ -34,7 +34,7 @@ namespace Xpense.API.Controllers
             try
             {
                 var result = await getCategoryByIdUseCase.Execute(id);
-                return Ok(result);
+                return new OkObjectResult(CategoryResponse.Of(result));
             }
             catch (CategoryNotFoundException exception)
             {
@@ -49,7 +49,7 @@ namespace Xpense.API.Controllers
             try
             {
                 await deleteCategoryByIdUseCase.Handle(id);
-                return Ok("CategoryId Deleted Successfully!");
+                return NoContent();
             }
             catch (CategoryDeletionFailedException exception)
             {
@@ -64,7 +64,7 @@ namespace Xpense.API.Controllers
             try
             {
                 var category = await createCategory.Handle(request.ToCommand());
-                return Ok(CreateCategoryResponse.Of(category));
+                return CreatedAtAction(nameof(GetById), new { id = category.Id }, CategoryResponse.Of(category));
             }
             catch (CategoryCreationFailedException exception)
             {
@@ -73,13 +73,14 @@ namespace Xpense.API.Controllers
             }
         }
 
-        [HttpPut]
-        public async Task<IActionResult> Update([FromBody] UpdateCategoryRequest request)
+        [HttpPut("{id:int}")]
+        public async Task<IActionResult> Update(int id, [FromBody] UpdateCategoryRequest request)
         {
             try
             {
+                request.Id = id;
                 var category = await updateCategoryUseCase.Handle(request.ToCommand());
-                return Ok(CategoryResponse.Of(category));
+                return new OkObjectResult(CategoryResponse.Of(category));
             }
             catch (CategoryNotFoundException exception)
             {

--- a/src/Xpense/Xpense.API/Controllers/MerchantController.cs
+++ b/src/Xpense/Xpense.API/Controllers/MerchantController.cs
@@ -7,7 +7,7 @@ using Xpense.Services.Features.Merchants.UseCases;
 
 namespace Xpense.API.Controllers
 {
-    [Route("api/merchant")]
+    [Route("api/v1/merchants")]
     [ApiController]
     public class MerchantController(
         GetAllMerchantsUseCase getAllMerchantsUse
@@ -17,7 +17,7 @@ namespace Xpense.API.Controllers
         public async Task<IActionResult> Get()
         {
             var merchants = await getAllMerchantsUse.Execute();
-            return Ok(merchants.Select(MerchantResponse.Of));
+            return new OkObjectResult(merchants.Select(MerchantResponse.Of));
         }
     }
 }

--- a/src/Xpense/Xpense.API/Controllers/TagController.cs
+++ b/src/Xpense/Xpense.API/Controllers/TagController.cs
@@ -11,7 +11,7 @@ using Xpense.Services.Features.Tags.UseCases;
 
 namespace Xpense.API.Controllers;
 
-[Route("api/tag")]
+[Route("api/v1/tags")]
 [ApiController]
 public class TagController(
     GetAllTagsUseCase getAllTagsUseCase,
@@ -26,7 +26,7 @@ public class TagController(
     public async Task<IActionResult> Get()
     {
         var tags = await getAllTagsUseCase.Execute();
-        return Ok(tags.Select(TagResponse.Of));
+        return new OkObjectResult(tags.Select(TagResponse.Of));
     }
 
     [HttpGet("{id:int}")]
@@ -35,7 +35,7 @@ public class TagController(
         try
         {
             var tag = await getTagByIdUseCase.Execute(id);
-            return Ok(TagResponse.Of(tag));
+            return new OkObjectResult(TagResponse.Of(tag));
         }
         catch (TagNotFoundException exception)
         {
@@ -50,7 +50,7 @@ public class TagController(
         try
         {
             await deleteTagUseCase.Handle(id);
-            return Ok("Tag Deleted Successfully!");
+            return NoContent();
         }
         catch (TagNotFoundException exception)
         {
@@ -73,7 +73,7 @@ public class TagController(
             request.FgColorHex = TrimHashSign(request.FgColorHex);
 
             var tag = await createTagUseCase.Handle(request.ToCommand());
-            return Ok(CreateTagResponse.Of(tag));
+            return CreatedAtAction(nameof(Get), new { id = tag.Id }, TagResponse.Of(tag));
         }
         catch (TagCreationFailedException exception)
         {
@@ -82,16 +82,17 @@ public class TagController(
         }
     }
 
-    [HttpPut]
-    public async Task<IActionResult> Update([FromBody] UpdateTagRequest request)
+    [HttpPut("{id:int}")]
+    public async Task<IActionResult> Update(int id, [FromBody] UpdateTagRequest request)
     {
         try
         {
+            request.Id = id;
             request.BgColorHex = TrimHashSign(request.BgColorHex);
             request.FgColorHex = TrimHashSign(request.FgColorHex);
 
             var tag = await updateTagUseCase.Handle(request.ToCommand());
-            return Ok(TagResponse.Of(tag));
+            return new OkObjectResult(TagResponse.Of(tag));
         }
         catch (TagNotFoundException exception)
         {

--- a/src/Xpense/Xpense.API/Controllers/TagController.cs
+++ b/src/Xpense/Xpense.API/Controllers/TagController.cs
@@ -30,7 +30,7 @@ public class TagController(
     }
 
     [HttpGet("{id:int}")]
-    public async Task<IActionResult> Get([FromRoute] int id)
+    public async Task<IActionResult> GetById([FromRoute] int id)
     {
         try
         {
@@ -73,7 +73,7 @@ public class TagController(
             request.FgColorHex = TrimHashSign(request.FgColorHex);
 
             var tag = await createTagUseCase.Handle(request.ToCommand());
-            return CreatedAtAction(nameof(Get), new { id = tag.Id }, TagResponse.Of(tag));
+            return CreatedAtAction(nameof(GetById), new { id = tag.Id }, TagResponse.Of(tag));
         }
         catch (TagCreationFailedException exception)
         {

--- a/src/Xpense/Xpense.API/Extensions.cs/IoC.cs
+++ b/src/Xpense/Xpense.API/Extensions.cs/IoC.cs
@@ -84,6 +84,7 @@ namespace Xpense.API.Extensions.cs
         public static void AddUseCases(this IServiceCollection services)
         {
             services.AddScoped<GetAccountByNumberUseCase>();
+            services.AddScoped<GetAccountByIdUseCase>();
             services.AddScoped<GetAllAccountsUseCase>();
             services.AddScoped<CreateAccountUseCase>();
             services.AddScoped<DeleteAccountUseCase>();

--- a/src/Xpense/Xpense.API/Models/Requests/UpdateAccountRequest.cs
+++ b/src/Xpense/Xpense.API/Models/Requests/UpdateAccountRequest.cs
@@ -2,11 +2,10 @@ using Xpense.Services.Features.Accounts.Commands;
 
 namespace Xpense.API.Models.Requests;
 
-public class UpdateAccountRequest(string number, string name, bool isDefault)
+public class UpdateAccountRequest(string name, bool isDefault)
 {
-    public string Number { get; set; } = number;
     public string Name { get; set; } = name;
     public bool IsDefault { get; set; } = isDefault;
 
-    public UpdateAccountCommand ToCommand() => new(Number, Name, IsDefault);
+    public UpdateAccountCommand ToCommand(int id) => new(id, Name, IsDefault);
 }

--- a/src/Xpense/Xpense.Services/Exceptions/AccountExceptions.cs
+++ b/src/Xpense/Xpense.Services/Exceptions/AccountExceptions.cs
@@ -1,7 +1,17 @@
 namespace Xpense.Services.Exceptions;
 
-public class AccountNotFoundException(string accountNumber, Exception? innerException = null)
-    : XpenseException($"Account with number {accountNumber} was not found!", innerException);
+public class AccountNotFoundException : XpenseException
+{
+    public AccountNotFoundException(string accountNumber, Exception? innerException = null)
+        : base($"Account with number {accountNumber} was not found!", innerException)
+    {
+    }
+
+    public AccountNotFoundException(int id, Exception? innerException = null)
+        : base($"Account with id {id} was not found!", innerException)
+    {
+    }
+}
 
 public class DefaultAccountNotFoundException(Exception? innerException = null)
     : XpenseException($"Account was not specified and no default account was found! ", innerException);

--- a/src/Xpense/Xpense.Services/Features/Accounts/Commands/UpdateAccountCommand.cs
+++ b/src/Xpense/Xpense.Services/Features/Accounts/Commands/UpdateAccountCommand.cs
@@ -1,8 +1,8 @@
 namespace Xpense.Services.Features.Accounts.Commands;
 
-public class UpdateAccountCommand(string number, string name, bool isDefault)
+public class UpdateAccountCommand(int id, string name, bool isDefault)
 {
-    public string Number { get; set; } = number;
+    public int Id { get; set; } = id;
     public string Name { get; set; } = name;
     public bool IsDefault { get; set; } = isDefault;
 }

--- a/src/Xpense/Xpense.Services/Features/Accounts/Usecases/CreateAccountUseCase.cs
+++ b/src/Xpense/Xpense.Services/Features/Accounts/Usecases/CreateAccountUseCase.cs
@@ -16,6 +16,7 @@ public class CreateAccountUseCase(IAccountRepository repository) : ICommandResul
             Balance = request.Balance,
             AccountNumber = repository.GetNextAccountNumber(),
             IsDefaultAccount = !repository.HasDefaultAccount(),
+            CreatedOn = DateTime.Now,
         };
 
         repository.Create(account);

--- a/src/Xpense/Xpense.Services/Features/Accounts/Usecases/DeleteAccountUseCase.cs
+++ b/src/Xpense/Xpense.Services/Features/Accounts/Usecases/DeleteAccountUseCase.cs
@@ -4,15 +4,19 @@ using Xpense.Services.Exceptions;
 
 namespace Xpense.Services.Features.Accounts.Usecases;
 
-public class DeleteAccountUseCase(IAccountRepository repository): ICommandHandler<string>
+public class DeleteAccountUseCase(IAccountRepository repository): ICommandHandler<int>
 {
-    public async Task Handle(string accountNumber)
+    public async Task Handle(int id)
     {
-       repository.DeleteAccountByNumber(accountNumber);
+       var account = await repository.GetById(id);
+       if (account == null)
+           throw new AccountNotFoundException(id);
+
+       repository.Delete(account);
        var result = await repository.SaveChanges();
        if (result < 1)
        {
-           throw new AccountUpdateFailedException(accountNumber);
+           throw new AccountUpdateFailedException(id.ToString());
        }
     }
 }

--- a/src/Xpense/Xpense.Services/Features/Accounts/Usecases/GetAccountByIdUseCase.cs
+++ b/src/Xpense/Xpense.Services/Features/Accounts/Usecases/GetAccountByIdUseCase.cs
@@ -1,0 +1,15 @@
+using Xpense.Services.Abstract.Persistence;
+using Xpense.Services.Abstract.UseCases;
+using Xpense.Services.Entities;
+using Xpense.Services.Exceptions;
+
+namespace Xpense.Services.Features.Accounts.Usecases;
+
+public class GetAccountByIdUseCase(IAccountRepository repository) : IQueryParamHandler<int, Account>
+{
+    public async Task<Account> Execute(int id, CancellationToken cancellationToken = default)
+    {
+        var account = await repository.GetById(id);
+        return account ?? throw new AccountNotFoundException(id);
+    }
+}

--- a/src/Xpense/Xpense.Services/Features/Accounts/Usecases/UpdateAccountUseCase.cs
+++ b/src/Xpense/Xpense.Services/Features/Accounts/Usecases/UpdateAccountUseCase.cs
@@ -11,13 +11,16 @@ public class UpdateAccountUseCase(IAccountRepository repository)
 {
     public async Task<Account> Handle(UpdateAccountCommand command)
     {
-        var account = await repository.GetAccountByNumber(command.Number);
+        var account = await repository.GetById(command.Id);
+        if (account == null)
+            throw new AccountNotFoundException(command.Id);
+
         account.Name = command.Name;
         account.IsDefaultAccount = command.IsDefault;
         repository.Update(account);
         var result = await repository.SaveChanges();
         if (result < 1)
-            throw new AccountUpdateFailedException(command.Number);
+            throw new AccountUpdateFailedException(command.Id.ToString());
         return account;
     }
 }

--- a/src/Xpense/Xpense.Services/Features/Categories/UseCases/CreateCategoryUseCase.cs
+++ b/src/Xpense/Xpense.Services/Features/Categories/UseCases/CreateCategoryUseCase.cs
@@ -21,7 +21,8 @@ public class CreateCategoryUseCase(
         var category = new Category()
         {
             Label = command.Name,
-            Priority = priority
+            Priority = priority,
+            CreatedOn = DateTime.Now
         };
 
         repository.Create(category);

--- a/src/Xpense/Xpense.Services/Features/Categories/UseCases/GetCategoryByIdUseCase.cs
+++ b/src/Xpense/Xpense.Services/Features/Categories/UseCases/GetCategoryByIdUseCase.cs
@@ -9,7 +9,7 @@ public class GetCategoryByIdUseCase(ICategoryRepository repository) : IQueryPara
 {
     public async Task<Category> Execute(int accountNumber, CancellationToken cancellationToken = default)
     {
-        var category = await repository.GetById(accountNumber);
+        var category = await repository.GetWithById(accountNumber, category => category.Priority);
         if (category == null)
             throw new CategoryNotFoundException(accountNumber);
         return category;

--- a/src/Xpense/Xpense.Services/Features/Tags/Commands/CreateTagCommand.cs
+++ b/src/Xpense/Xpense.Services/Features/Tags/Commands/CreateTagCommand.cs
@@ -12,6 +12,7 @@ public class CreateTagCommand(string label, string bgColorHex, string fgColorHex
     {
         Label = Label,
         BgColorHex = BgColorHex,
-        FgColorHex = FgColorHex
+        FgColorHex = FgColorHex,
+        CreatedOn = DateTime.Now
     };
 }

--- a/src/Xpense/Xpense.Tests/Integration/V1ResourceEndpointTests.cs
+++ b/src/Xpense/Xpense.Tests/Integration/V1ResourceEndpointTests.cs
@@ -23,11 +23,15 @@ public class V1ResourceEndpointTests
         using var factory = new WebApiTestFactory();
         using var client = factory.CreateClient();
 
+        await SeedAccount(factory);
+
         var response = await client.GetAsync(route);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         document.RootElement.ValueKind.Should().Be(JsonValueKind.Array);
+        if (route == "/api/v1/accounts")
+            document.RootElement[0].GetProperty("label").GetString().Should().Be("Cash");
     }
 
     [TestCase("/api/category")]
@@ -115,6 +119,106 @@ public class V1ResourceEndpointTests
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
 
+    [Test]
+    public async Task Get_accounts_by_id_returns_the_direct_resource()
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+        await SeedAccount(factory);
+
+        var response = await client.GetAsync("/api/v1/accounts/1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("id").GetInt32().Should().Be(1);
+        document.RootElement.GetProperty("label").GetString().Should().Be("Cash");
+    }
+
+    [Test]
+    public async Task Put_accounts_updates_the_resource_id_and_delete_returns_no_content()
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+        await SeedAccount(factory);
+
+        var updateResponse = await client.PutAsync(
+            "/api/v1/accounts/1",
+            JsonBody("{\"name\":\"Updated Cash\",\"isDefault\":false}"));
+        var deleteResponse = await client.DeleteAsync("/api/v1/accounts/1");
+
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await updateResponse.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("label").GetString().Should().Be("Updated Cash");
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Test]
+    public async Task Get_categories_by_id_returns_the_direct_resource()
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+        await SeedCategory(factory);
+
+        var response = await client.GetAsync("/api/v1/categories/1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("id").GetInt32().Should().Be(1);
+        document.RootElement.GetProperty("label").GetString().Should().Be("Food");
+    }
+
+    [Test]
+    public async Task Put_categories_updates_the_resource_id_and_delete_returns_no_content()
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+        await SeedCategory(factory);
+
+        var updateResponse = await client.PutAsync(
+            "/api/v1/categories/1",
+            JsonBody("{\"name\":\"Dining\",\"priorityId\":1}"));
+        var deleteResponse = await client.DeleteAsync("/api/v1/categories/1");
+
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await updateResponse.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("label").GetString().Should().Be("Dining");
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Test]
+    public async Task Put_tags_updates_the_resource_id_and_delete_returns_no_content()
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+        var createResponse = await client.PostAsync(
+            "/api/v1/tags",
+            JsonBody("{\"label\":\"Travel\",\"bgColorHex\":\"#ffffff\",\"fgColorHex\":\"#000000\"}"));
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var updateResponse = await client.PutAsync(
+            "/api/v1/tags/1",
+            JsonBody("{\"name\":\"Holiday\",\"bgColorHex\":\"#123456\",\"fgColorHex\":\"#abcdef\"}"));
+        var deleteResponse = await client.DeleteAsync("/api/v1/tags/1");
+
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await updateResponse.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("label").GetString().Should().Be("Holiday");
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [TestCase("/api/account")]
+    [TestCase("/api/account/1000000000")]
+    [TestCase("/api/v1/accounts/1000000000")]
+    public async Task Legacy_account_number_item_and_collection_put_routes_are_not_available(string route)
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PutAsync(route, JsonBody("{\"name\":\"Cash\",\"isDefault\":true}"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
     private static StringContent JsonBody(string json) => new(json, Encoding.UTF8, "application/json");
 
     private static async Task SeedAccount(WebApiTestFactory factory)
@@ -140,6 +244,20 @@ public class V1ResourceEndpointTests
         {
             Label = "Normal",
             Weight = 1,
+            CreatedOn = DateTime.UtcNow
+        });
+        await dbContext.SaveChangesAsync();
+    }
+
+    private static async Task SeedCategory(WebApiTestFactory factory)
+    {
+        await SeedPriority(factory);
+        using var scope = factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<XpenseDbContext>();
+        dbContext.Categories.Add(new Category
+        {
+            Label = "Food",
+            PriorityId = 1,
             CreatedOn = DateTime.UtcNow
         });
         await dbContext.SaveChangesAsync();

--- a/src/Xpense/Xpense.Tests/Integration/V1ResourceEndpointTests.cs
+++ b/src/Xpense/Xpense.Tests/Integration/V1ResourceEndpointTests.cs
@@ -1,0 +1,147 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Xpense.Persistence;
+using Xpense.Services.Entities;
+using Xpense.Tests.Infrastructure;
+
+namespace Xpense.Tests.Integration;
+
+[TestFixture]
+public class V1ResourceEndpointTests
+{
+    [TestCase("/api/v1/accounts")]
+    [TestCase("/api/v1/categories")]
+    [TestCase("/api/v1/tags")]
+    [TestCase("/api/v1/merchants")]
+    public async Task Get_resource_collections_uses_plural_v1_routes_and_returns_resources_directly(string route)
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync(route);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.ValueKind.Should().Be(JsonValueKind.Array);
+    }
+
+    [TestCase("/api/category")]
+    [TestCase("/api/tag")]
+    [TestCase("/api/merchant")]
+    public async Task Legacy_singular_resource_routes_are_not_available(string route)
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync(route);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Test]
+    public async Task Post_accounts_returns_created_resource_at_its_id_route()
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+        await SeedAccount(factory);
+
+        var response = await client.PostAsync(
+            "/api/v1/accounts",
+            JsonBody("{\"name\":\"Savings\",\"balance\":123.45}"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.Location.Should().Be(new Uri("http://localhost/api/v1/accounts/2"));
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("id").GetInt32().Should().Be(2);
+        document.RootElement.GetProperty("label").GetString().Should().Be("Savings");
+    }
+
+    [Test]
+    public async Task Post_categories_returns_created_resource_at_its_id_route()
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+        await SeedPriority(factory);
+
+        var response = await client.PostAsync(
+            "/api/v1/categories",
+            JsonBody("{\"name\":\"Food\",\"priorityId\":1}"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.Location.Should().Be(new Uri("http://localhost/api/v1/categories/1"));
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("id").GetInt32().Should().Be(1);
+        document.RootElement.GetProperty("label").GetString().Should().Be("Food");
+    }
+
+    [Test]
+    public async Task Post_tags_returns_created_resource_at_its_id_route()
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync(
+            "/api/v1/tags",
+            JsonBody("{\"label\":\"Travel\",\"bgColorHex\":\"#ffffff\",\"fgColorHex\":\"#000000\"}"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.Location.Should().Be(new Uri("http://localhost/api/v1/tags/1"));
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("id").GetInt32().Should().Be(1);
+        document.RootElement.GetProperty("label").GetString().Should().Be("Travel");
+
+        var getResponse = await client.GetAsync(response.Headers.Location);
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Delete_tags_uses_the_resource_id_route_and_returns_no_content()
+    {
+        using var factory = new WebApiTestFactory();
+        using var client = factory.CreateClient();
+        var createResponse = await client.PostAsync(
+            "/api/v1/tags",
+            JsonBody("{\"label\":\"Travel\",\"bgColorHex\":\"#ffffff\",\"fgColorHex\":\"#000000\"}"));
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        createResponse.Headers.Location.Should().Be(new Uri("http://localhost/api/v1/tags/1"));
+
+        var response = await client.DeleteAsync(createResponse.Headers.Location);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    private static StringContent JsonBody(string json) => new(json, Encoding.UTF8, "application/json");
+
+    private static async Task SeedAccount(WebApiTestFactory factory)
+    {
+        using var scope = factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<XpenseDbContext>();
+        dbContext.Accounts.Add(new Account
+        {
+            Name = "Cash",
+            AccountNumber = "1000000000",
+            Balance = 0,
+            CreatedOn = DateTime.UtcNow,
+            IsDefaultAccount = true
+        });
+        await dbContext.SaveChangesAsync();
+    }
+
+    private static async Task SeedPriority(WebApiTestFactory factory)
+    {
+        using var scope = factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<XpenseDbContext>();
+        dbContext.Priorities.Add(new Priority
+        {
+            Label = "Normal",
+            Weight = 1,
+            CreatedOn = DateTime.UtcNow
+        });
+        await dbContext.SaveChangesAsync();
+    }
+}


### PR DESCRIPTION
**#31 was merged into `pr/02-test-host` instead of `main`.** Its base was never retargeted after #30 landed, because the repo has `delete_branch_on_merge: false` — GitHub only retargets a stacked PR when its base branch is *deleted* on merge. #30 got retargeted only because `pr/01-ci-fix` was deleted manually; `pr/02-test-host` was not, so #31 had a live base to merge into and its commits never reached `main`.

This carries that already-reviewed work across. The diff is exactly #31's content — `pr/02-test-host` also holds #30, which is already in `main`, so it contributes nothing here.

Commits landing:

- `f40b5e3` feat: move resource endpoints to api v1
- `f2e87ba` fix: complete v1 resource contracts
- `e7df446` fix(api): register GetAccountByIdUseCase
- `a7a94fa` style(api): put the account route attributes on one line

**18 files.** Nothing new to review — this is #31, re-pointed.

---

**To stop this recurring** for #32–#39, pick one:

1. Set `delete_branch_on_merge: true` on the repo — GitHub then retargets each child automatically as its parent merges. One setting, no per-PR discipline.
2. Delete the base branch by hand right after each merge, as you did for `pr/01-ci-fix`.
3. Retarget the next PR to `main` yourself before merging it.

I'd take option 1.