### PR TITLE
chore: ignore the Rider .idea directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -397,6 +397,7 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.idea/
 
 # Test and coverage output, produced by the CI coverage step and by local runs
 TestResults/

--- a/src/Xpense/.idea/.idea.Xpense/.idea/indexLayout.xml
+++ b/src/Xpense/.idea/.idea.Xpense/.idea/indexLayout.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="UserContentModel">
-    <attachedFolders />
-    <explicitIncludes />
-    <explicitExcludes />
-  </component>
-</project>

--- a/src/Xpense/.idea/.idea.Xpense/.idea/vcs.xml
+++ b/src/Xpense/.idea/.idea.Xpense/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
-  </component>
-</project>


### PR DESCRIPTION
The Rider block in `.gitignore` only covered `*.sln.iml`, so `.idea/` files kept getting staged — `indexLayout.xml` and `vcs.xml` were already tracked.

- add `.idea/` to the JetBrains Rider section
- untrack `indexLayout.xml` and `vcs.xml` (files stay on disk)