### PR TITLE
feat: budgets, recurring and one-off

### DIFF
--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -9,10 +9,10 @@ or a payment app such as Tikkie — and Xpense records the fact that it happened
 Users will be able to record money moving to each other on the platform, which is
 the one place where the record is shared rather than personal.
 
-> This model is implemented. See [docs/model-rename-pass.md](docs/model-rename-pass.md) for what
-> changed and the ADRs in [docs/adr/](docs/adr/) for why. **User** and **Owner** are the exception:
-> they are in the language because the **Transaction** model depends on them, and they do not exist
-> in code yet.
+> This model is implemented, [Budgeting](#budgeting) included. See
+> [docs/model-rename-pass.md](docs/model-rename-pass.md) for what changed and the ADRs in
+> [docs/adr/](docs/adr/) for why. **User** and **Owner** are the exception: they are in the language
+> because the **Transaction** model depends on them, and they do not exist in code yet.
 
 ## Money
 
@@ -114,6 +114,50 @@ optional and unlimited on any **Transaction**.
 
 **Label** is the one word for a human-readable name, in code, in the database and on the wire.
 
+## Budgeting
+
+| Term              | Definition                                                                              | Aliases to avoid                          |
+| ----------------- | --------------------------------------------------------------------------------------- | ----------------------------------------- |
+| **Budget**        | An intended limit on **Expense** for one **Category**, in one **Currency**, over a **Budget period** | Cap, allowance, envelope, target, quota   |
+| **Budget period** | The window of time a **Budget** measures **Expenses** in: a calendar week, month or year when it repeats, otherwise any stretch of dates | Cycle, month, term, range |
+| **Recurrence**    | How a **Budget** repeats: not at all, or once per week, month or year                     | Schedule, frequency, interval, repeat     |
+| **Spent**         | The total **Money** of **Expenses** in a **Budget**'s **Category** and **Currency** within its period | Used, consumed, actual, burn         |
+| **Remaining**     | A **Budget**'s amount minus **Spent**, negative once exceeded                            | Left, available, **Balance**              |
+
+A **Budget** reports and never blocks. Xpense records money that has already moved, so a
+**Budget** cannot refuse a **Transaction** — refusing the record would not un-spend the
+money, it would only make Xpense disagree with the bank.
+
+**Remaining** is deliberately not called a balance. **Balance** is **Money** an **Account**
+holds; **Remaining** is the unused part of an intention, and the two must not be confused.
+
+Only **Expenses** count. A **Transfer** has no **Category** and is money you still own, so
+it is never spending. **Income** is not spending either. Like all reporting, a **Budget**
+measures by **Occurred at**, so a purchase entered today but made last month counts against
+last month.
+
+A **Budget** has one **Currency**, and only **Expenses** in that **Currency** count toward
+it — nothing converts here either. A **Category** spans **Accounts** and therefore
+**Currencies**, so spending in another **Currency** is reported as explicitly not counted
+rather than dropped in silence. Two **Currencies** worth of groceries means two **Budgets**.
+
+One entity covers both shapes. A one-off **Budget** has no **Recurrence** and one fixed window;
+a repeating one has a **Recurrence** and may run indefinitely. There is no separate "recurring
+budget" — that would be two entities differing by one column, which is the mistake
+[ADR 0001](docs/adr/0001-one-transaction-entity-with-two-nullable-sides.md) already corrected
+once.
+
+A repeating **Budget**'s periods are calendar weeks, months or years, so each has a name —
+`2026-W32`, `2026-08`, `2026` — that a client, a report and a notification can all mean the same
+thing by. A one-off **Budget** may cover any stretch of dates.
+
+**Budgets** are independent of one another. Xpense does not compare them, rank them, or refuse
+one for overlapping another: several may cover the same **Category** at once, in different
+**Currencies**, over different lengths, or over the very same days. **Spent** and **Remaining**
+belong to a **Budget** and not to a **Category**, so each **Budget** answers only for itself and
+no rule decides which of two applies. Keeping a set of **Budgets** coherent is the user's
+business, not Xpense's.
+
 ## Relationships
 
 - An **Account** is denominated in exactly one **Currency**, fixed for its life
@@ -124,6 +168,9 @@ optional and unlimited on any **Transaction**.
 - A **Transaction** has zero or more **Tags**
 - A **Category** has exactly one **Priority**; a **Priority** covers zero or more **Categories**
 - A **Transfer**'s two **Accounts** and its amount all share one **Currency**
+- A **Budget** covers exactly one **Category** and is denominated in one **Currency**
+- A **Category** has zero or more **Budgets**, which need not agree with each other
+- A **Budget** counts **Expenses** only, never **Income** and never **Transfers**
 
 ## Example dialogue
 

--- a/docs/adr/0006-a-budget-reports-and-never-blocks.md
+++ b/docs/adr/0006-a-budget-reports-and-never-blocks.md
@@ -1,0 +1,68 @@
+---
+status: accepted
+date: 2026-08-05
+---
+
+# A Budget reports and never blocks
+
+Recording an **Expense** that exceeds a **Budget** succeeds. There is no budget check in
+`Transaction.Expense`, none in `CreateTransaction`, and no field on the transaction response
+saying a **Budget** was crossed. **Budget** is a read-side concept: it owns queries that compute
+**Spent** and **Remaining**, and nothing else in the system consults it.
+
+Detecting that a **Budget** was crossed belongs to the notification consumer, which reads a
+`TransactionRecorded` event and decides for itself what is noteworthy.
+
+## Why
+
+Xpense is a ledger. `UBIQUITOUS_LANGUAGE.md` opens with it: "It records money that has already
+moved and reports on it. Xpense never holds money itself." The money left the bank before Xpense
+heard about it. A **Budget** that refused the record would not un-spend anything — it would only
+make Xpense disagree with the bank, which is the one thing a ledger must never do. The recorded
+**Balance** would drift from the real one, and the fix would be to delete the **Budget**.
+
+That settles blocking. It does not settle where the *warning* lives, and the first answer is
+tempting and wrong: put the crossed budgets on the `POST /transactions` response. That couples
+two features that have no reason to know about each other, makes every transaction create pay for
+a budget query, and builds a worse version of something already planned — a central notifications
+feature, decoupled by a queue, where producers raise events and a job consumes, stores and serves
+them. Budget-exceeded is one event type among several, next to transaction recorded and account
+changed.
+
+Given a queue, the crossing has a natural home that is not this feature. Transactions raise one
+event saying a **Transaction** happened — which that epic needs regardless. The consumer reads
+it and decides what matters, including asking **Budget** whether anything was crossed. Producers
+stay ignorant of who cares, which is the entire point of putting a queue between them.
+
+So **Budget** never touches the write path, now or later. Whether a given **Expense** crossed a
+**Budget** is computable from the **Transaction** and the **Budget** alone — the sum before it
+against the sum after — so nothing is lost by not capturing the moment today.
+
+## Considered options
+
+**A hard cap that rejects the Expense**, enforced in the domain the way
+`InsufficientFundsForTransferException` already is. Genuinely prevents overspending in an app used
+with discipline. Rejected because it contradicts the premise above: the money already moved.
+
+**Budget evaluation in the write path, raising a `BudgetExceeded` event.** Captures the exact
+moment of crossing, and leaves the consumer dumb — it stores and serves whatever arrives. Rejected
+because it designs one event's contract before the epic that owns all of them exists, ships an
+outbox nothing reads, and makes every transaction create pay for a budget query. Its only real
+advantage, knowing *when* the crossing happened, is recoverable later from the data.
+
+**The crossing stored on the Budget row** — `ExceededAt`, `ExceededBy`, updated on write. Cheapest
+way to answer "when did I go over". Rejected because it is derived state stored next to the data
+it derives from: edit or delete the **Expense** and the columns lie. That is exactly the
+contradiction the derived **Transaction kind** was introduced to make impossible
+([ADR 0001](0001-one-transaction-entity-with-two-nullable-sides.md)).
+
+## Consequences
+
+Nothing tells you that you went over until you look, or until the notifications feature exists.
+That is the accepted cost of not guessing that feature's shape from inside this one.
+
+`Transaction` keeps its current invariants and `CreateTransaction` its current cost. A future
+change that adds a budget guard to either is reversing this decision, not extending it.
+
+"You went over on the 14th" is not answerable yet. It becomes answerable when the notification
+consumer starts recording what it observed, without any change here.

--- a/docs/adr/0007-budgets-are-independent-of-one-another.md
+++ b/docs/adr/0007-budgets-are-independent-of-one-another.md
@@ -1,0 +1,72 @@
+---
+status: accepted
+date: 2026-08-05
+---
+
+# Budgets are independent of one another
+
+Nothing rejects two **Budgets** that cover the same **Category** at the same time. Several may
+overlap — in different **Currencies**, over different lengths, or over the very same days — and
+there is no precedence rule deciding which one applies. **Spent** and **Remaining** belong to a
+**Budget**, not to a **Category**, so each answers only for itself.
+
+There is therefore no override concept, no "most specific wins", and no uniqueness constraint
+beyond the obvious keys.
+
+## Why
+
+The alternative was arrived at first and then abandoned, which is worth recording because the
+missing validation looks like an oversight.
+
+The reasoning that produced it went: a **Budget** should have one **Remaining**, so exactly one
+**Budget** may apply per **Category** and period, so "300 a month except 500 in December" needs an
+override row plus a rule saying it wins. Adding weekly and yearly periods then required that rule
+to decide which *length* an override displaced. Wanting a holiday budget over an arbitrary stretch
+of days broke it entirely: a 20-day window contains no whole week and sits inside one month, so
+"the shortest period fully containing it" answers nothing useful.
+
+Every one of those knots came from the single-**Remaining** premise, and that premise was never a
+requirement. It was carried over from rejecting **Tag**-scoped **Budgets**, where overlap really is
+a problem — a **Tag** budget silently double-counts one **Expense** across several budgets that are
+each claiming to be *the* answer for that spending. Two **Budgets** deliberately created on one
+**Category** are not that. They are two intentions, and a user who writes both meant both.
+
+Once **Remaining** belongs to a **Budget** rather than to a **Category**, overlap stops being a
+contradiction to resolve and becomes data to report. A weekly guard under a monthly ceiling is
+expressible. A holiday window alongside a monthly plan is expressible. Neither needs a rule,
+because neither is competing to be the same number.
+
+Keeping a set of **Budgets** coherent is the user's business. Xpense records intentions the way it
+records movements: as stated, without arbitration.
+
+## Considered options
+
+**Exactly one Budget per Category, Currency and period, with one-off Budgets overriding recurring
+ones.** Gives **Remaining** a single answer per **Category** and makes the December case one row.
+Rejected because the precedence rule has no sound answer for arbitrary windows, and because it
+forbids a weekly budget and a monthly budget coexisting — two things a user might reasonably want
+at once.
+
+**Reject any overlap at creation.** No precedence rule at all, and single-answer **Remaining**
+guaranteed by a constraint rather than by logic. Rejected because changing one month becomes three
+operations — end the recurring **Budget**, state the exception, start a new recurring one — with a
+gap in coverage if the third is forgotten, and because it still forbids the weekly-plus-monthly
+pair.
+
+**A row materialised per period**, so editing one period is editing its row. Genuinely avoids
+precedence and keeps per-period history. Rejected as machinery the problem did not require once
+overlap stopped being an error: something must generate the rows, they can drift from the rule
+that made them, and an ungenerated period needs defined behaviour.
+
+## Consequences
+
+A client cannot ask "what is my Groceries budget" and get one answer, because that question is not
+well-formed here. It asks a **Budget** for its **Remaining**, or lists the **Budgets** on a
+**Category**.
+
+A user can create two contradictory **Budgets** and Xpense will report both without comment. That
+is deliberate. If it ever proves to be a real problem, the fix is a warning in a client or a
+notification, not a constraint here.
+
+Nothing needs a precedence rule, so nothing needs a rule for what happens when the periods have
+different lengths — which is what made arbitrary windows safe to allow.

--- a/src/Xpense/Xpense.API/Features/Analytics/GetSpendingByCategory.cs
+++ b/src/Xpense/Xpense.API/Features/Analytics/GetSpendingByCategory.cs
@@ -39,29 +39,42 @@ public sealed class GetSpendingByCategory : IEndpoint
                                   && transaction.OccurredAt.Date == today)
             .ToListAsync(ct);
 
-        if (expensesToday.Count == 0)
-            return TypedResults.Ok(new SpendingByCategoryResponse([], new MoneyResponse(0, nameof(Currency.EUR))));
-
-        var currency = expensesToday[0].Currency.ToString();
-
+        // Grouped by currency as well as by category, because nothing converts. This used to label
+        // the whole total with expensesToday[0].Currency and sum minor units across every currency
+        // in the day, so 10 EUR and 10 USD reported as 2000 EUR -- money invented by addition.
         var byCategory = expensesToday
-            .GroupBy(transaction => transaction.Category!)
+            .GroupBy(transaction => new { transaction.Category!.Id, transaction.Currency })
             .Select(group => new CategorySpendingResponse(
                 group.Key.Id,
-                CategoryResponse.Of(group.Key),
-                new MoneyResponse(group.Sum(transaction => transaction.AmountMinorUnits), currency)))
+                CategoryResponse.Of(group.First().Category!),
+                new MoneyResponse(group.Sum(transaction => transaction.AmountMinorUnits), group.Key.Currency.ToString())))
+            .OrderBy(spending => spending.Id)
+            .ThenBy(spending => spending.Amount.Currency)
             .ToArray();
 
-        var total = new MoneyResponse(expensesToday.Sum(transaction => transaction.AmountMinorUnits), currency);
+        // One total per currency present. An empty day has no currency to speak for, so it has no
+        // totals rather than a zero in a currency nobody used.
+        var totals = expensesToday
+            .GroupBy(transaction => transaction.Currency)
+            .Select(group => new MoneyResponse(group.Sum(transaction => transaction.AmountMinorUnits), group.Key.ToString()))
+            .OrderBy(total => total.Currency)
+            .ToArray();
 
-        return TypedResults.Ok(new SpendingByCategoryResponse(byCategory, total));
+        return TypedResults.Ok(new SpendingByCategoryResponse(byCategory, totals));
     }
 }
 
+/// <summary>
+/// <paramref name="Totals"/> is one entry per currency spent today, never a single summed figure:
+/// adding amounts in different currencies produces a number that is true of nothing.
+/// </summary>
 public sealed record SpendingByCategoryResponse(
     CategorySpendingResponse[] Expenses,
-    MoneyResponse Total);
+    MoneyResponse[] Totals);
 
+/// <summary>
+/// One category's spending in one currency. A category spent in two currencies appears twice.
+/// </summary>
 public sealed record CategorySpendingResponse(
     int Id,
     CategoryResponse Category,

--- a/src/Xpense/Xpense.API/Features/Budgets/BudgetResponse.cs
+++ b/src/Xpense/Xpense.API/Features/Budgets/BudgetResponse.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Xpense.API.Contracts;
+using Xpense.Domain.Entities;
+using Xpense.Domain.ValueObjects;
+
+namespace Xpense.API.Features.Budgets;
+
+/// <summary>
+/// Shared by all five budget slices: a budget looks the same however you fetched it.
+/// <para>
+/// <c>StartsOn</c> and <c>EndsOn</c> are dates rather than timestamps, so they cross the wire as
+/// yyyy-MM-dd. A budget starts on a day, not at an instant, and sending midnight UTC would invite a
+/// client to render it in local time and show the day before.
+/// </para>
+/// </summary>
+public sealed record BudgetResponse(
+    int Id,
+    CategoryResponse Category,
+    MoneyResponse Amount,
+    string Recurrence,
+    string StartsOn,
+    string? EndsOn,
+    BudgetPeriodResponse? Period,
+    string CreatedAt,
+    string? UpdatedAt)
+{
+    public static BudgetResponse Of(Budget budget, BudgetPeriodResponse? period) => new(
+        budget.Id,
+        CategoryResponse.Of(budget.Category!),
+        MoneyResponse.Of(budget.Amount),
+        budget.Recurrence.ToString(),
+        Day(budget.StartsOn),
+        budget.EndsOn is null ? null : Day(budget.EndsOn.Value),
+        period,
+        Timestamps.Iso(budget.CreatedAt),
+        Timestamps.Iso(budget.UpdatedAt));
+
+    private static string Day(DateTime value) => value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+}
+
+/// <summary>
+/// What one budget measured over one of its periods. Null on a budget that measures nothing at the
+/// moment asked about -- before it starts, after it ends, or a one-off outside its window.
+/// <para>
+/// <c>Uncounted</c> is spending on this budget's category inside this period that is in a different
+/// currency, and so counts toward nothing here. It is reported rather than dropped: Xpense never
+/// converts, and money that silently vanishes from a report is the failure this makes visible.
+/// </para>
+/// </summary>
+public sealed record BudgetPeriodResponse(
+    string Name,
+    string From,
+    string ToExclusive,
+    MoneyResponse Spent,
+    MoneyResponse Remaining,
+    bool Exceeded,
+    MoneyResponse[] Uncounted)
+{
+    public static BudgetPeriodResponse Of(
+        BudgetPeriod period,
+        Money limit,
+        Money spent,
+        IEnumerable<Money> uncounted) => new(
+        period.Name,
+        Timestamps.Iso(period.From),
+        Timestamps.Iso(period.ToExclusive),
+        MoneyResponse.Of(spent),
+        MoneyResponse.Of(limit - spent),
+        spent > limit,
+        uncounted.Select(MoneyResponse.Of).ToArray());
+}

--- a/src/Xpense/Xpense.API/Features/Budgets/CreateBudget.cs
+++ b/src/Xpense/Xpense.API/Features/Budgets/CreateBudget.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentValidation;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using Xpense.API.Infrastructure;
+using Xpense.Domain.Entities;
+using Xpense.Domain.Enums;
+using Xpense.Domain.Exceptions;
+using Xpense.Domain.ValueObjects;
+using Xpense.Persistence;
+
+namespace Xpense.API.Features.Budgets;
+
+/// <summary>
+/// States a budget. Nothing checks it against any other budget: several may cover one category at
+/// once and Xpense does not arbitrate, per
+/// docs/adr/0007-budgets-are-independent-of-one-another.md.
+/// </summary>
+public sealed class CreateBudget : IEndpoint
+{
+    public sealed record Request(
+        int CategoryId,
+        MoneyRequest Amount,
+        string Recurrence,
+        DateOnly StartsOn,
+        DateOnly? EndsOn);
+
+    public sealed record MoneyRequest(long MinorUnits, string Currency);
+
+    public sealed class Validator : AbstractValidator<Request>
+    {
+        public Validator()
+        {
+            RuleFor(request => request.CategoryId)
+                .GreaterThan(0).WithMessage("The categoryId must reference an existing category.");
+
+            RuleFor(request => request.Amount)
+                .NotNull().WithMessage("The amount is required.");
+
+            When(request => request.Amount is not null, () =>
+            {
+                RuleFor(request => request.Amount.MinorUnits)
+                    .GreaterThan(0).WithMessage("The amount in minor units must be positive.");
+
+                RuleFor(request => request.Amount.Currency)
+                    .Must(currency => CurrencyParser.TryParse(currency, out _))
+                    .WithMessage("The currency must be a supported currency name.");
+            });
+
+            RuleFor(request => request.Recurrence)
+                .Must(recurrence => RecurrenceParser.TryParse(recurrence, out _))
+                .WithMessage("The recurrence must be one of None, Weekly, Monthly or Yearly.");
+
+            // Both of these are guarded in Budget as well. That is not redundancy to remove: this
+            // produces a good 400 for a bad request, and the domain guard makes the state
+            // unreachable through any future caller.
+            RuleFor(request => request.EndsOn)
+                .NotNull()
+                .When(request => IsOneOff(request.Recurrence))
+                .WithMessage("A budget that does not repeat must state when it ends.");
+
+            RuleFor(request => request.EndsOn)
+                .Must((request, endsOn) => endsOn is null || endsOn >= request.StartsOn)
+                .WithMessage("The endsOn date cannot be before startsOn.");
+        }
+
+        private static bool IsOneOff(string recurrence) =>
+            RecurrenceParser.TryParse(recurrence, out var parsed) && parsed == Recurrence.None;
+    }
+
+    public static void Map(IEndpointRouteBuilder app) =>
+        app.MapPost("/api/v1/budgets", Handle).WithName(nameof(CreateBudget)).Validated();
+
+    private static async Task<Created<BudgetResponse>> Handle(
+        Request request,
+        XpenseDbContext db,
+        HttpContext http,
+        CancellationToken ct)
+    {
+        var category = await db.Categories
+            .Include(item => item.Priority)
+            .FirstOrDefaultAsync(item => item.Id == request.CategoryId, ct)
+            ?? throw new CategoryNotFoundException(request.CategoryId);
+
+        CurrencyParser.TryParse(request.Amount.Currency, out var currency);
+        RecurrenceParser.TryParse(request.Recurrence, out var recurrence);
+
+        var budget = Budget.For(
+            category,
+            Money.OfMinorUnits(request.Amount.MinorUnits, currency),
+            recurrence,
+            request.StartsOn.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc),
+            request.EndsOn?.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc));
+
+        db.Budgets.Add(budget);
+
+        if (await db.SaveChangesAsync(ct) < 1)
+            throw new BudgetCreationFailedException(request.CategoryId);
+
+        // A freshly stated budget has measured nothing worth reporting yet, and the caller asked to
+        // create rather than to read, so no period is computed here.
+        return TypedResults.Created(
+            http.ResourceUri($"/api/v1/budgets/{budget.Id}"),
+            BudgetResponse.Of(budget, null));
+    }
+}

--- a/src/Xpense/Xpense.API/Features/Budgets/DeleteBudget.cs
+++ b/src/Xpense/Xpense.API/Features/Budgets/DeleteBudget.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using Xpense.API.Infrastructure;
+using Xpense.Domain.Exceptions;
+using Xpense.Persistence;
+
+namespace Xpense.API.Features.Budgets;
+
+public sealed class DeleteBudget : IEndpoint
+{
+    public static void Map(IEndpointRouteBuilder app) =>
+        app.MapDelete("/api/v1/budgets/{id:int}", Handle).WithName(nameof(DeleteBudget));
+
+    private static async Task<NoContent> Handle(int id, XpenseDbContext db, CancellationToken ct)
+    {
+        var budget = await db.Budgets.FirstOrDefaultAsync(item => item.Id == id, ct)
+                     ?? throw new BudgetNotFoundException(id);
+
+        budget.MarkAsDeleted();
+        budget.Touch();
+
+        if (await db.SaveChangesAsync(ct) < 1)
+            throw new BudgetDeletionFailedException(id);
+
+        return TypedResults.NoContent();
+    }
+}

--- a/src/Xpense/Xpense.API/Features/Budgets/GetBudgetById.cs
+++ b/src/Xpense/Xpense.API/Features/Budgets/GetBudgetById.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using Xpense.API.Infrastructure;
+using Xpense.Domain.Exceptions;
+using Xpense.Domain.ValueObjects;
+using Xpense.Persistence;
+
+namespace Xpense.API.Features.Budgets;
+
+/// <summary>
+/// One budget and what it has measured over one of its periods.
+/// <para>
+/// Unlike <see cref="ListBudgets"/>, the totals are summed in the database and grouped by currency
+/// there: with a single budget there is one window to ask about, so nothing has to be sorted out in
+/// memory afterwards.
+/// </para>
+/// </summary>
+public sealed class GetBudgetById : IEndpoint
+{
+    public static void Map(IEndpointRouteBuilder app) =>
+        app.MapGet("/api/v1/budgets/{id:int}", Handle).WithName(nameof(GetBudgetById));
+
+    private static async Task<Ok<BudgetResponse>> Handle(
+        int id,
+        XpenseDbContext db,
+        CancellationToken ct,
+        DateTimeOffset? on = null)
+    {
+        var instant = on?.UtcDateTime ?? DateTime.UtcNow;
+
+        var budget = await db.Budgets
+            .AsNoTracking()
+            .Include(item => item.Category)
+            .ThenInclude(category => category!.Priority)
+            .FirstOrDefaultAsync(item => item.Id == id, ct)
+            ?? throw new BudgetNotFoundException(id);
+
+        var period = budget.PeriodOn(instant);
+
+        if (period is null)
+            return TypedResults.Ok(BudgetResponse.Of(budget, null));
+
+        var totals = await db.Transactions
+            .AsNoTracking()
+            .Where(transaction => transaction.SourceAccountId != null
+                                  && transaction.DestinationAccountId == null
+                                  && transaction.CategoryId == budget.CategoryId
+                                  && transaction.OccurredAt >= period.From
+                                  && transaction.OccurredAt < period.ToExclusive)
+            .GroupBy(transaction => transaction.Currency)
+            .Select(group => new
+            {
+                Currency = group.Key,
+                MinorUnits = group.Sum(transaction => transaction.AmountMinorUnits)
+            })
+            .ToListAsync(ct);
+
+        // Built in the budget's own currency: Money.Zero is EUR, and a EUR zero taken from a USD
+        // limit throws instead of returning the limit untouched.
+        var spent = Money.OfMinorUnits(
+            totals.SingleOrDefault(total => total.Currency == budget.Currency)?.MinorUnits ?? 0,
+            budget.Currency);
+
+        var uncounted = totals
+            .Where(total => total.Currency != budget.Currency)
+            .OrderBy(total => total.Currency)
+            .Select(total => Money.OfMinorUnits(total.MinorUnits, total.Currency))
+            .ToArray();
+
+        return TypedResults.Ok(
+            BudgetResponse.Of(budget, BudgetPeriodResponse.Of(period, budget.Amount, spent, uncounted)));
+    }
+}

--- a/src/Xpense/Xpense.API/Features/Budgets/ListBudgets.cs
+++ b/src/Xpense/Xpense.API/Features/Budgets/ListBudgets.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using Xpense.API.Infrastructure;
+using Xpense.Domain.Enums;
+using Xpense.Domain.ValueObjects;
+using Xpense.Persistence;
+
+namespace Xpense.API.Features.Budgets;
+
+/// <summary>
+/// Every budget with what it has measured so far, ready for a dashboard in one request.
+/// <para>
+/// Spending is fetched with a single query covering every budget in the list rather than one query
+/// per budget, so ten budgets cost two round trips and not eleven. The window asked for spans the
+/// earliest period start to the latest period end, which over-fetches when a weekly budget and a
+/// yearly one appear together -- one wide filtered read beats N narrow ones.
+/// </para>
+/// </summary>
+public sealed class ListBudgets : IEndpoint
+{
+    public static void Map(IEndpointRouteBuilder app) =>
+        app.MapGet("/api/v1/budgets", Handle).WithName(nameof(ListBudgets));
+
+    private static async Task<Ok<BudgetResponse[]>> Handle(
+        XpenseDbContext db,
+        CancellationToken ct,
+        DateTimeOffset? on = null)
+    {
+        // Which period a budget is in depends on a moment. Default to now; `?on=` asks about another.
+        var instant = on?.UtcDateTime ?? DateTime.UtcNow;
+
+        var budgets = await db.Budgets
+            .AsNoTracking()
+            .Include(budget => budget.Category)
+            .ThenInclude(category => category!.Priority)
+            .OrderBy(budget => budget.CategoryId)
+            .ThenBy(budget => budget.Id)
+            .ToListAsync(ct);
+
+        var measured = budgets
+            .Select(budget => (Budget: budget, Period: budget.PeriodOn(instant)))
+            .ToArray();
+
+        var active = measured.Where(entry => entry.Period is not null).ToArray();
+
+        if (active.Length == 0)
+            return TypedResults.Ok(measured.Select(entry => BudgetResponse.Of(entry.Budget, null)).ToArray());
+
+        var categoryIds = active.Select(entry => entry.Budget.CategoryId).Distinct().ToArray();
+        var from = active.Min(entry => entry.Period!.From);
+        var toExclusive = active.Max(entry => entry.Period!.ToExclusive);
+
+        // Expenses only, and the filter is written as columns because Kind is computed. A transfer
+        // has no category to count against, and income is not spending.
+        var expenses = await db.Transactions
+            .AsNoTracking()
+            .Where(transaction => transaction.SourceAccountId != null
+                                  && transaction.DestinationAccountId == null
+                                  && transaction.CategoryId != null
+                                  && categoryIds.Contains(transaction.CategoryId.Value)
+                                  && transaction.OccurredAt >= from
+                                  && transaction.OccurredAt < toExclusive)
+            .Select(transaction => new Expense(
+                transaction.CategoryId!.Value,
+                transaction.Currency,
+                transaction.OccurredAt,
+                transaction.AmountMinorUnits))
+            .ToListAsync(ct);
+
+        var responses = measured
+            .Select(entry => entry.Period is null
+                ? BudgetResponse.Of(entry.Budget, null)
+                : BudgetResponse.Of(entry.Budget, Measure(entry.Budget.Amount, entry.Budget.CategoryId, entry.Period, expenses)))
+            .ToArray();
+
+        return TypedResults.Ok(responses);
+    }
+
+    private static BudgetPeriodResponse Measure(
+        Money limit,
+        int categoryId,
+        BudgetPeriod period,
+        List<Expense> expenses)
+    {
+        var inPeriod = expenses
+            .Where(expense => expense.CategoryId == categoryId && period.Contains(expense.OccurredAt))
+            .ToArray();
+
+        // Zero has to be built in this budget's currency. Money.Zero is EUR, and subtracting a EUR
+        // zero from a USD limit throws rather than returning the limit.
+        var spent = Money.OfMinorUnits(
+            inPeriod.Where(expense => expense.Currency == limit.Currency).Sum(expense => expense.MinorUnits),
+            limit.Currency);
+
+        var uncounted = inPeriod
+            .Where(expense => expense.Currency != limit.Currency)
+            .GroupBy(expense => expense.Currency)
+            .Select(group => Money.OfMinorUnits(group.Sum(expense => expense.MinorUnits), group.Key))
+            .OrderBy(money => money.Currency)
+            .ToArray();
+
+        return BudgetPeriodResponse.Of(period, limit, spent, uncounted);
+    }
+
+    private sealed record Expense(int CategoryId, Currency Currency, DateTime OccurredAt, long MinorUnits);
+}

--- a/src/Xpense/Xpense.API/Features/Budgets/UpdateBudget.cs
+++ b/src/Xpense/Xpense.API/Features/Budgets/UpdateBudget.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentValidation;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using Xpense.API.Infrastructure;
+using Xpense.Domain.Enums;
+using Xpense.Domain.Exceptions;
+using Xpense.Domain.ValueObjects;
+using Xpense.Persistence;
+
+namespace Xpense.API.Features.Budgets;
+
+/// <summary>
+/// Restates a budget's limit and window. The category is not among them: a budget for a different
+/// category is a different budget, the same way an account's currency is fixed for its life.
+/// </summary>
+public sealed class UpdateBudget : IEndpoint
+{
+    public sealed record Request(
+        MoneyRequest Amount,
+        string Recurrence,
+        DateOnly StartsOn,
+        DateOnly? EndsOn);
+
+    public sealed record MoneyRequest(long MinorUnits, string Currency);
+
+    public sealed class Validator : AbstractValidator<Request>
+    {
+        public Validator()
+        {
+            RuleFor(request => request.Amount)
+                .NotNull().WithMessage("The amount is required.");
+
+            When(request => request.Amount is not null, () =>
+            {
+                RuleFor(request => request.Amount.MinorUnits)
+                    .GreaterThan(0).WithMessage("The amount in minor units must be positive.");
+
+                RuleFor(request => request.Amount.Currency)
+                    .Must(currency => CurrencyParser.TryParse(currency, out _))
+                    .WithMessage("The currency must be a supported currency name.");
+            });
+
+            RuleFor(request => request.Recurrence)
+                .Must(recurrence => RecurrenceParser.TryParse(recurrence, out _))
+                .WithMessage("The recurrence must be one of None, Weekly, Monthly or Yearly.");
+
+            RuleFor(request => request.EndsOn)
+                .NotNull()
+                .When(request => IsOneOff(request.Recurrence))
+                .WithMessage("A budget that does not repeat must state when it ends.");
+
+            RuleFor(request => request.EndsOn)
+                .Must((request, endsOn) => endsOn is null || endsOn >= request.StartsOn)
+                .WithMessage("The endsOn date cannot be before startsOn.");
+        }
+
+        private static bool IsOneOff(string recurrence) =>
+            RecurrenceParser.TryParse(recurrence, out var parsed) && parsed == Recurrence.None;
+    }
+
+    public static void Map(IEndpointRouteBuilder app) =>
+        app.MapPut("/api/v1/budgets/{id:int}", Handle).WithName(nameof(UpdateBudget)).Validated();
+
+    private static async Task<Ok<BudgetResponse>> Handle(
+        int id,
+        Request request,
+        XpenseDbContext db,
+        CancellationToken ct)
+    {
+        var budget = await db.Budgets
+            .Include(item => item.Category)
+            .ThenInclude(category => category!.Priority)
+            .FirstOrDefaultAsync(item => item.Id == id, ct)
+            ?? throw new BudgetNotFoundException(id);
+
+        CurrencyParser.TryParse(request.Amount.Currency, out var currency);
+        RecurrenceParser.TryParse(request.Recurrence, out var recurrence);
+
+        budget.Restate(
+            Money.OfMinorUnits(request.Amount.MinorUnits, currency),
+            recurrence,
+            request.StartsOn.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc),
+            request.EndsOn?.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc));
+
+        if (await db.SaveChangesAsync(ct) < 1)
+            throw new BudgetUpdateFailedException(id);
+
+        return TypedResults.Ok(BudgetResponse.Of(budget, null));
+    }
+}

--- a/src/Xpense/Xpense.API/Features/Categories/DeleteCategory.cs
+++ b/src/Xpense/Xpense.API/Features/Categories/DeleteCategory.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -25,6 +26,19 @@ public sealed class DeleteCategory : IEndpoint
 
         category.MarkAsDeleted();
         category.Touch();
+
+        // A budget on a category nobody can see measures nothing anyone can ask about, so it goes
+        // with it. This also keeps budget reads from ever meeting a null category: the global query
+        // filter hides the row, and an Include would hand back null for a category that is still
+        // referenced. Budget is an entity rather than another slice's type, so reaching it from here
+        // does not cross a slice boundary.
+        var budgets = await db.Budgets.Where(budget => budget.CategoryId == id).ToListAsync(ct);
+
+        foreach (var budget in budgets)
+        {
+            budget.MarkAsDeleted();
+            budget.Touch();
+        }
 
         if (await db.SaveChangesAsync(ct) < 1)
             throw new CategoryDeletionFailedException(id);

--- a/src/Xpense/Xpense.API/Features/Priorities/ListPriorities.cs
+++ b/src/Xpense/Xpense.API/Features/Priorities/ListPriorities.cs
@@ -1,0 +1,39 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using Xpense.API.Contracts;
+using Xpense.API.Infrastructure;
+using Xpense.Persistence;
+
+namespace Xpense.API.Features.Priorities;
+
+/// <summary>
+/// The priorities a category can be given. Read-only: they are reference data, seeded by a migration
+/// rather than created through the API.
+/// <para>
+/// This exists because a category requires a priority id and nothing exposed the ids. A client had
+/// to hardcode 1 to 5 and hope the seed never changed.
+/// </para>
+/// </summary>
+public sealed class ListPriorities : IEndpoint
+{
+    public static void Map(IEndpointRouteBuilder app) =>
+        app.MapGet("/api/v1/priorities", Handle).WithName(nameof(ListPriorities));
+
+    private static async Task<Ok<PriorityResponse[]>> Handle(XpenseDbContext db, CancellationToken ct)
+    {
+        // By id, which is seed order: Extreme, High, Medium, Low, None. Weight would put None first,
+        // because None weighs 0 and Extreme weighs 1.
+        var priorities = await db.Priorities
+            .AsNoTracking()
+            .OrderBy(priority => priority.Id)
+            .ToListAsync(ct);
+
+        return TypedResults.Ok(priorities.Select(PriorityResponse.Of).ToArray());
+    }
+}

--- a/src/Xpense/Xpense.Domain/Entities/Budget.cs
+++ b/src/Xpense/Xpense.Domain/Entities/Budget.cs
@@ -1,0 +1,186 @@
+using System.Globalization;
+using Xpense.Domain.Enums;
+using Xpense.Domain.Exceptions;
+using Xpense.Domain.ValueObjects;
+
+namespace Xpense.Domain.Entities;
+
+/// <summary>
+/// An intended limit on expense for one category, in one currency, over a period.
+/// <para>
+/// A budget reports and never blocks. Nothing consults it when a transaction is recorded, because
+/// Xpense records money that has already moved -- refusing the record would not un-spend anything,
+/// it would only make Xpense disagree with the bank. See
+/// docs/adr/0006-a-budget-reports-and-never-blocks.md.
+/// </para>
+/// <para>
+/// Budgets do not know about each other. Several may cover one category at once, in different
+/// currencies, over different lengths, or over the very same days, and nothing here arbitrates
+/// between them: <c>Spent</c> and <c>Remaining</c> belong to a budget, not to a category. See
+/// docs/adr/0007-budgets-are-independent-of-one-another.md.
+/// </para>
+/// <para>
+/// One entity covers both shapes. A one-off is a budget with no <see cref="Recurrence"/> and a
+/// fixed window; a repeating one has a recurrence and may run indefinitely. A second entity
+/// differing by one column is the mistake ADR 0001 already corrected once.
+/// </para>
+/// </summary>
+public class Budget : BaseEntity
+{
+    /// <summary>The limit in minor units of <see cref="Currency"/>. Mapped; prefer <see cref="Amount"/>.</summary>
+    public long AmountMinorUnits { get; set; }
+
+    /// <summary>
+    /// The currency this budget is stated in. Only expenses in this currency count toward it --
+    /// nothing converts, here or anywhere else in Xpense.
+    /// </summary>
+    public Currency Currency { get; set; }
+
+    /// <summary>The limit as money. Not mapped -- projected from the two columns above.</summary>
+    public Money Amount => Money.OfMinorUnits(AmountMinorUnits, Currency);
+
+    public int CategoryId { get; set; }
+
+    public Category? Category { get; set; }
+
+    public Recurrence Recurrence { get; set; }
+
+    /// <summary>The first day this budget is in force, as a UTC date.</summary>
+    public DateTime StartsOn { get; set; }
+
+    /// <summary>
+    /// The last day this budget is in force, inclusive, as a UTC date. Null means it runs
+    /// indefinitely, which only a repeating budget may do.
+    /// </summary>
+    public DateTime? EndsOn { get; set; }
+
+    /// <summary>The first instant after this budget's life. Open-ended budgets never reach it.</summary>
+    private DateTime LifeToExclusive => EndsOn?.AddDays(1) ?? DateTime.MaxValue;
+
+    public static Budget For(
+        Category category,
+        Money amount,
+        Recurrence recurrence,
+        DateTime startsOn,
+        DateTime? endsOn)
+    {
+        if (amount.MinorUnits <= 0)
+            throw new InvalidBudgetException("A budget amount must be positive.");
+
+        var (from, to) = RequireValidWindow(recurrence, startsOn, endsOn);
+
+        return new Budget
+        {
+            Category = category,
+            AmountMinorUnits = amount.MinorUnits,
+            Currency = amount.Currency,
+            Recurrence = recurrence,
+            StartsOn = from,
+            EndsOn = to,
+            CreatedAt = DateTime.UtcNow
+        };
+    }
+
+    /// <summary>
+    /// Restates an existing budget's limit and window. The category is not among them: a budget for
+    /// a different category is a different budget, the same way an account's currency is fixed for
+    /// its life.
+    /// </summary>
+    public void Restate(Money amount, Recurrence recurrence, DateTime startsOn, DateTime? endsOn)
+    {
+        if (amount.MinorUnits <= 0)
+            throw new InvalidBudgetException("A budget amount must be positive.");
+
+        var (from, to) = RequireValidWindow(recurrence, startsOn, endsOn);
+
+        AmountMinorUnits = amount.MinorUnits;
+        Currency = amount.Currency;
+        Recurrence = recurrence;
+        StartsOn = from;
+        EndsOn = to;
+        Touch();
+    }
+
+    private static (DateTime From, DateTime? To) RequireValidWindow(
+        Recurrence recurrence,
+        DateTime startsOn,
+        DateTime? endsOn)
+    {
+        var from = UtcDate(startsOn);
+        var to = endsOn is null ? null : (DateTime?)UtcDate(endsOn.Value);
+
+        // A budget that never repeats has exactly one window, so it has to say where that window
+        // stops. Open-ended only means anything for a repeating one.
+        if (recurrence == Recurrence.None && to is null)
+            throw new InvalidBudgetException("A budget that does not repeat must state when it ends.");
+
+        if (to is not null && to < from)
+            throw new InvalidBudgetException("A budget cannot end before it starts.");
+
+        return (from, to);
+    }
+
+    /// <summary>
+    /// The period this budget measures at the given instant, or null when it measures nothing then.
+    /// </summary>
+    public BudgetPeriod? PeriodOn(DateTime instant)
+    {
+        if (Recurrence == Recurrence.None)
+        {
+            var only = OnlyPeriod();
+            return only.Contains(instant) ? only : null;
+        }
+
+        var period = CalendarPeriodContaining(instant);
+
+        // Whether a repeating budget is measuring is decided by the period overlapping its life,
+        // not by the instant being inside that life. A monthly budget starting on the 15th measures
+        // the whole of that month -- so asking about the 3rd has to give the same answer as asking
+        // about the 20th, or the same period would report two different totals.
+        return period.Overlaps(StartsOn, LifeToExclusive) ? period : null;
+    }
+
+    private BudgetPeriod OnlyPeriod() =>
+        new(StartsOn, LifeToExclusive, $"{Day(StartsOn)}..{Day(EndsOn!.Value)}");
+
+    private BudgetPeriod CalendarPeriodContaining(DateTime instant) => Recurrence switch
+    {
+        Recurrence.Weekly => Week(instant),
+        Recurrence.Monthly => Month(instant),
+        Recurrence.Yearly => Year(instant),
+        _ => throw new InvalidBudgetException($"Unsupported recurrence {Recurrence}.")
+    };
+
+    /// <summary>
+    /// ISO 8601 weeks: Monday to Sunday, and week 1 is the one holding the first Thursday.
+    /// <para>
+    /// The year in the name comes from <see cref="ISOWeek.GetYear"/> and not from the instant,
+    /// because they disagree at the boundary -- 2027-01-01 falls in week 53 of 2026, and naming it
+    /// 2027-W53 would name a week that does not exist.
+    /// </para>
+    /// </summary>
+    private static BudgetPeriod Week(DateTime instant)
+    {
+        var weekYear = ISOWeek.GetYear(instant);
+        var week = ISOWeek.GetWeekOfYear(instant);
+        var monday = DateTime.SpecifyKind(ISOWeek.ToDateTime(weekYear, week, DayOfWeek.Monday), DateTimeKind.Utc);
+
+        return new BudgetPeriod(monday, monday.AddDays(7), $"{weekYear:0000}-W{week:00}");
+    }
+
+    private static BudgetPeriod Month(DateTime instant)
+    {
+        var first = new DateTime(instant.Year, instant.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+        return new BudgetPeriod(first, first.AddMonths(1), $"{instant.Year:0000}-{instant.Month:00}");
+    }
+
+    private static BudgetPeriod Year(DateTime instant)
+    {
+        var first = new DateTime(instant.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        return new BudgetPeriod(first, first.AddYears(1), $"{instant.Year:0000}");
+    }
+
+    private static DateTime UtcDate(DateTime value) => DateTime.SpecifyKind(value.Date, DateTimeKind.Utc);
+
+    private static string Day(DateTime value) => value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+}

--- a/src/Xpense/Xpense.Domain/Enums/Recurrence.cs
+++ b/src/Xpense/Xpense.Domain/Enums/Recurrence.cs
@@ -1,0 +1,18 @@
+namespace Xpense.Domain.Enums;
+
+/// <summary>
+/// How a budget repeats. <see cref="None"/> means it covers one window and never comes back.
+/// <para>
+/// The repeating values name calendar periods rather than lengths of time, so every period a budget
+/// measures has a name -- 2026-W32, 2026-08, 2026 -- that a client, a report and a notification can
+/// all mean the same thing by. "Every 30 days" and "from the 25th" are deliberately not expressible:
+/// they would make a period something you compute rather than something you can refer to.
+/// </para>
+/// </summary>
+public enum Recurrence
+{
+    None,
+    Weekly,
+    Monthly,
+    Yearly
+}

--- a/src/Xpense/Xpense.Domain/Enums/RecurrenceParser.cs
+++ b/src/Xpense/Xpense.Domain/Enums/RecurrenceParser.cs
@@ -1,0 +1,21 @@
+namespace Xpense.Domain.Enums;
+
+public static class RecurrenceParser
+{
+    /// <summary>
+    /// Parses a recurrence name, case-insensitively, rejecting numeric input.
+    /// <para>
+    /// Same reason as <see cref="CurrencyParser"/>: <c>Enum.TryParse</c> accepts "0" and every other
+    /// number in range, so a client posting <c>"recurrence": "0"</c> would silently get
+    /// <see cref="Recurrence.None"/> -- and a budget that does not repeat when it was meant to.
+    /// </para>
+    /// </summary>
+    public static bool TryParse(string value, out Recurrence recurrence)
+    {
+        recurrence = default;
+
+        return !string.IsNullOrWhiteSpace(value)
+               && Enum.GetNames<Recurrence>().Any(name => string.Equals(name, value, StringComparison.OrdinalIgnoreCase))
+               && Enum.TryParse(value, ignoreCase: true, out recurrence);
+    }
+}

--- a/src/Xpense/Xpense.Domain/Exceptions/BudgetExceptions.cs
+++ b/src/Xpense/Xpense.Domain/Exceptions/BudgetExceptions.cs
@@ -1,0 +1,20 @@
+namespace Xpense.Domain.Exceptions;
+
+/// <summary>
+/// A budget was asked for that breaks its own rules -- a non-positive amount, an end before its
+/// start, or a one-off with no end at all.
+/// </summary>
+public class InvalidBudgetException(string message, Exception? innerException = null)
+    : DomainRuleViolationException(message, innerException);
+
+public class BudgetNotFoundException(int id, Exception? innerException = null)
+    : NotFoundException($"Budget with id {id} was not found!", innerException);
+
+public class BudgetCreationFailedException(int categoryId, Exception? innerException = null)
+    : PersistenceFailedException($"Failed attempt to create a budget for category {categoryId}", innerException);
+
+public class BudgetUpdateFailedException(int id, Exception? innerException = null)
+    : PersistenceFailedException($"Failed to update budget with id {id}", innerException);
+
+public class BudgetDeletionFailedException(int id, Exception? innerException = null)
+    : PersistenceFailedException($"Failed attempt to remove budget {id}", innerException);

--- a/src/Xpense/Xpense.Domain/ValueObjects/BudgetPeriod.cs
+++ b/src/Xpense/Xpense.Domain/ValueObjects/BudgetPeriod.cs
@@ -1,0 +1,25 @@
+namespace Xpense.Domain.ValueObjects;
+
+/// <summary>
+/// The window of time a budget measures expenses in, and the name that window goes by.
+/// <para>
+/// Half-open on purpose: <paramref name="From"/> is inside the period and
+/// <paramref name="ToExclusive"/> is not, so one period ends exactly where the next begins with no
+/// gap and no overlap. An inclusive end would mean choosing a last instant, and every choice of
+/// last instant is wrong for something -- 23:59:59 loses the final second, 23:59:59.9999999 is a
+/// number nobody would guess.
+/// </para>
+/// </summary>
+/// <param name="From">The first instant inside the period, in UTC.</param>
+/// <param name="ToExclusive">The first instant after the period, in UTC.</param>
+/// <param name="Name">
+/// What this period is called: <c>2026-W32</c>, <c>2026-08</c>, <c>2026</c>, or a date range for a
+/// budget that does not repeat.
+/// </param>
+public sealed record BudgetPeriod(DateTime From, DateTime ToExclusive, string Name)
+{
+    public bool Contains(DateTime instant) => instant >= From && instant < ToExclusive;
+
+    /// <summary>Whether this period shares any time at all with the half-open window given.</summary>
+    public bool Overlaps(DateTime from, DateTime toExclusive) => From < toExclusive && ToExclusive > from;
+}

--- a/src/Xpense/Xpense.Persistence/Migrations/20260805144400_AddBudgets.Designer.cs
+++ b/src/Xpense/Xpense.Persistence/Migrations/20260805144400_AddBudgets.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Xpense.Persistence;
@@ -11,9 +12,11 @@ using Xpense.Persistence;
 namespace Xpense.Persistence.Migrations
 {
     [DbContext(typeof(XpenseDbContext))]
-    partial class XpenseDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260805144400_AddBudgets")]
+    partial class AddBudgets
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Xpense/Xpense.Persistence/Migrations/20260805144400_AddBudgets.cs
+++ b/src/Xpense/Xpense.Persistence/Migrations/20260805144400_AddBudgets.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Xpense.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBudgets : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Budgets",
+                schema: "Xpense",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    AmountMinorUnits = table.Column<long>(type: "bigint", nullable: false),
+                    Currency = table.Column<int>(type: "integer", nullable: false),
+                    CategoryId = table.Column<int>(type: "integer", nullable: false),
+                    Recurrence = table.Column<int>(type: "integer", nullable: false),
+                    StartsOn = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    EndsOn = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Budgets", x => x.Id);
+                    table.CheckConstraint("CK_Budget_Amount_Positive", " \"AmountMinorUnits\" > 0 ");
+                    table.CheckConstraint("CK_Budget_Ends_On_Or_After_Start", " \"EndsOn\" IS NULL OR \"EndsOn\" >= \"StartsOn\" ");
+                    table.ForeignKey(
+                        name: "FK_Budgets_Categories_CategoryId",
+                        column: x => x.CategoryId,
+                        principalSchema: "Xpense",
+                        principalTable: "Categories",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Budgets_CategoryId_StartsOn",
+                schema: "Xpense",
+                table: "Budgets",
+                columns: new[] { "CategoryId", "StartsOn" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Budgets",
+                schema: "Xpense");
+        }
+    }
+}

--- a/src/Xpense/Xpense.Persistence/TypeConfiguration/BudgetEntityTypeConfiguration.cs
+++ b/src/Xpense/Xpense.Persistence/TypeConfiguration/BudgetEntityTypeConfiguration.cs
@@ -1,0 +1,45 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Xpense.Domain.Entities;
+
+namespace Xpense.Persistence.TypeConfiguration;
+
+public class BudgetEntityTypeConfiguration : BaseEntityTypeConfiguration<Budget>
+{
+    public override void Configure(EntityTypeBuilder<Budget> builder)
+    {
+        base.Configure(builder);
+        builder.Metadata.SetSchema(XpenseSchema);
+
+        // Amount is projected from AmountMinorUnits and Currency, not stored.
+        builder.Ignore(e => e.Amount);
+
+        // Budget (M) - Category (1). No collection on Category: nothing needs to walk that way, and
+        // adding one would put a navigation on Category that only this feature reads. Restrict
+        // because a category is soft-deleted rather than removed -- DeleteCategory soft-deletes the
+        // budgets pointing at it in the same operation.
+        builder.HasOne(e => e.Category)
+            .WithMany()
+            .HasForeignKey(e => e.CategoryId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // Every read starts from a category and a window.
+        builder.HasIndex(e => new { e.CategoryId, e.StartsOn });
+
+        // The factory enforces these too. That is not redundancy to remove: a migration, a script or
+        // a future caller can write a row without going through it.
+        builder.ToTable(table =>
+        {
+            table.HasCheckConstraint("CK_Budget_Amount_Positive", """ "AmountMinorUnits" > 0 """);
+
+            table.HasCheckConstraint(
+                "CK_Budget_Ends_On_Or_After_Start",
+                """ "EndsOn" IS NULL OR "EndsOn" >= "StartsOn" """);
+        });
+
+        // "A budget that does not repeat must have an end" is deliberately *not* a check constraint.
+        // Saying it in SQL means writing the Recurrence enum's integer value into the schema, and an
+        // enum whose numbers ended up in two places is exactly how Credit and Debit came to disagree
+        // with TransferLegDirection. It lives in Budget.For and Budget.Restate instead.
+    }
+}

--- a/src/Xpense/Xpense.Persistence/XpenseDbContext.cs
+++ b/src/Xpense/Xpense.Persistence/XpenseDbContext.cs
@@ -19,6 +19,7 @@ namespace Xpense.Persistence
         public virtual DbSet<Category> Categories { get; set; }
         public virtual DbSet<Priority> Priorities { get; set; }
         public virtual DbSet<Tag> Tags { get; set; }
+        public virtual DbSet<Budget> Budgets { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/src/Xpense/Xpense.Tests/Integration/ApiEndpointTests.cs
+++ b/src/Xpense/Xpense.Tests/Integration/ApiEndpointTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Xpense.Persistence;
 using Xpense.Domain.Entities;
 using Xpense.Domain.Enums;
+using Xpense.Domain.ValueObjects;
 using Xpense.Tests.Infrastructure;
 
 namespace Xpense.Tests.Integration;
@@ -742,8 +743,10 @@ public class ApiEndpointTests
         using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         var summary = document.RootElement;
         summary.TryGetProperty("data", out _).Should().BeFalse();
-        summary.GetProperty("total").GetProperty("minorUnits").GetInt64().Should().Be(1250);
-        summary.GetProperty("total").GetProperty("currency").GetString().Should().Be("EUR");
+        var totals = summary.GetProperty("totals");
+        totals.GetArrayLength().Should().Be(1);
+        totals[0].GetProperty("minorUnits").GetInt64().Should().Be(1250);
+        totals[0].GetProperty("currency").GetString().Should().Be("EUR");
         var expenses = summary.GetProperty("expenses");
         expenses.GetArrayLength().Should().Be(1);
         expenses[0].GetProperty("category").GetProperty("label").GetString().Should().Be("Food");
@@ -763,7 +766,236 @@ public class ApiEndpointTests
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
-        document.RootElement.GetProperty("total").GetProperty("minorUnits").GetInt64().Should().Be(1250);
+        var totals = document.RootElement.GetProperty("totals");
+        totals.GetArrayLength().Should().Be(1);
+        totals[0].GetProperty("minorUnits").GetInt64().Should().Be(1250);
+    }
+
+    /// <summary>
+    /// This used to label the whole day with the first expense's currency and add every minor unit
+    /// together, so 12.50 EUR and 7.00 USD reported as 19.50 EUR -- money created by addition.
+    /// </summary>
+    [Test]
+    public async Task Get_spending_by_category_never_sums_across_currencies()
+    {
+        await SeedTodayExpensesInTwoCurrencies();
+
+        var response = await client.GetAsync("/api/v1/analytics/spending/by-category");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+
+        var totals = document.RootElement.GetProperty("totals");
+        totals.GetArrayLength().Should().Be(2);
+        totals.EnumerateArray()
+            .Select(total => (total.GetProperty("currency").GetString(), total.GetProperty("minorUnits").GetInt64()))
+            .Should().BeEquivalentTo([("EUR", 1250L), ("USD", 700L)]);
+
+        // One category, two currencies, so two lines -- never one line holding a nonsense sum.
+        var expenses = document.RootElement.GetProperty("expenses");
+        expenses.GetArrayLength().Should().Be(2);
+        expenses.EnumerateArray()
+            .Select(expense => expense.GetProperty("amount").GetProperty("minorUnits").GetInt64())
+            .Should().NotContain(1950);
+    }
+
+    // ---------------------------------------------------------------- priorities
+
+    /// <summary>
+    /// Also proves the SeedPriorities migration ran: these five rows come from the schema, not from
+    /// anything this test wrote.
+    /// </summary>
+    [Test]
+    public async Task Get_priorities_returns_the_reference_data_seeded_by_the_migration()
+    {
+        var response = await client.GetAsync("/api/v1/priorities");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetArrayLength().Should().Be(5);
+        document.RootElement.EnumerateArray()
+            .Select(priority => priority.GetProperty("label").GetString())
+            .Should().Equal("Extreme", "High", "Medium", "Low", "None");
+    }
+
+    // ---------------------------------------------------------------- budgets
+
+    [Test]
+    public async Task Post_budgets_returns_the_created_resource_at_its_id_route()
+    {
+        var categoryId = await SeedCategoryReturningId();
+
+        var response = await client.PostAsync("/api/v1/budgets", NewBudgetBody(categoryId, 30000, "Monthly"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.Location.Should().Be(new Uri("http://localhost/api/v1/budgets/1"));
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("recurrence").GetString().Should().Be("Monthly");
+        document.RootElement.GetProperty("amount").GetProperty("minorUnits").GetInt64().Should().Be(30000);
+        document.RootElement.GetProperty("category").GetProperty("label").GetString().Should().Be("Food");
+        document.RootElement.GetProperty("startsOn").GetString().Should().Be(FirstOfThisMonth());
+    }
+
+    /// <summary>
+    /// A budget that does not repeat has exactly one window, so it has to say where that window ends.
+    /// Guarded by the validator here and by Budget.For underneath it.
+    /// </summary>
+    [Test]
+    public async Task Post_budgets_rejects_a_one_off_with_no_end()
+    {
+        var categoryId = await SeedCategoryReturningId();
+
+        var response = await client.PostAsync("/api/v1/budgets", NewBudgetBody(categoryId, 30000, "None"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Content.Headers.ContentType!.MediaType.Should().Be(ProblemJson);
+    }
+
+    [Test]
+    public async Task Get_budgets_reports_spent_and_remaining_for_the_period_holding_today()
+    {
+        await SeedBudgetWithTodaysExpense(limitMinorUnits: 30000, spentMinorUnits: 1250);
+
+        var response = await client.GetAsync("/api/v1/budgets");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var period = document.RootElement[0].GetProperty("period");
+        period.GetProperty("name").GetString().Should().Be($"{DateTime.UtcNow:yyyy-MM}");
+        period.GetProperty("spent").GetProperty("minorUnits").GetInt64().Should().Be(1250);
+        period.GetProperty("remaining").GetProperty("minorUnits").GetInt64().Should().Be(28750);
+        period.GetProperty("exceeded").GetBoolean().Should().BeFalse();
+        period.GetProperty("uncounted").GetArrayLength().Should().Be(0);
+    }
+
+    [Test]
+    public async Task Get_budgets_by_id_marks_a_budget_exceeded_and_reports_a_negative_remaining()
+    {
+        await SeedBudgetWithTodaysExpense(limitMinorUnits: 1000, spentMinorUnits: 1250);
+
+        var response = await client.GetAsync("/api/v1/budgets/1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var period = document.RootElement.GetProperty("period");
+        period.GetProperty("spent").GetProperty("minorUnits").GetInt64().Should().Be(1250);
+        period.GetProperty("remaining").GetProperty("minorUnits").GetInt64().Should().Be(-250);
+        period.GetProperty("exceeded").GetBoolean().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A budget counts one currency. Spending the same category in another is reported as uncounted
+    /// rather than converted or, worse, added in.
+    /// </summary>
+    [Test]
+    public async Task Get_budgets_reports_spending_in_other_currencies_as_uncounted()
+    {
+        await SeedBudgetWithTodaysExpense(limitMinorUnits: 30000, spentMinorUnits: 1250, alsoSpendUsd: 700);
+
+        var response = await client.GetAsync("/api/v1/budgets/1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var period = document.RootElement.GetProperty("period");
+        period.GetProperty("spent").GetProperty("minorUnits").GetInt64().Should().Be(1250);
+        var uncounted = period.GetProperty("uncounted");
+        uncounted.GetArrayLength().Should().Be(1);
+        uncounted[0].GetProperty("currency").GetString().Should().Be("USD");
+        uncounted[0].GetProperty("minorUnits").GetInt64().Should().Be(700);
+    }
+
+    /// <summary>
+    /// Spending means expenses. A transfer has no category to count against, and income is not
+    /// spending -- the same rule the analytics slice follows.
+    /// </summary>
+    [Test]
+    public async Task Get_budgets_counts_neither_income_nor_transfers()
+    {
+        await SeedBudgetWithTodaysExpense(
+            limitMinorUnits: 30000, spentMinorUnits: 1250, alsoSeedIncomeAndTransfer: true);
+
+        var response = await client.GetAsync("/api/v1/budgets/1");
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("period").GetProperty("spent")
+            .GetProperty("minorUnits").GetInt64().Should().Be(1250);
+    }
+
+    /// <summary>
+    /// Two budgets on one category are two intentions, and Xpense reports both without arbitrating.
+    /// See docs/adr/0007-budgets-are-independent-of-one-another.md.
+    /// </summary>
+    [Test]
+    public async Task Get_budgets_reports_every_budget_on_a_category_without_choosing_between_them()
+    {
+        var categoryId = await SeedCategoryReturningId();
+        await client.PostAsync("/api/v1/budgets", NewBudgetBody(categoryId, 30000, "Monthly"));
+        await client.PostAsync("/api/v1/budgets", NewBudgetBody(categoryId, 10000, "Weekly"));
+
+        var response = await client.GetAsync("/api/v1/budgets");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetArrayLength().Should().Be(2);
+        document.RootElement.EnumerateArray()
+            .Select(budget => budget.GetProperty("period").GetProperty("name").GetString())
+            .Should().BeEquivalentTo([$"{DateTime.UtcNow:yyyy-MM}", IsoWeekName(DateTime.UtcNow)]);
+    }
+
+    [Test]
+    public async Task Get_budgets_reports_no_period_for_a_one_off_whose_window_has_passed()
+    {
+        var categoryId = await SeedCategoryReturningId();
+
+        await client.PostAsync("/api/v1/budgets", JsonBody(
+            $"{{\"categoryId\":{categoryId},\"amount\":{{\"minorUnits\":20000,\"currency\":\"EUR\"}},"
+            + "\"recurrence\":\"None\",\"startsOn\":\"2020-01-01\",\"endsOn\":\"2020-01-31\"}"));
+
+        var response = await client.GetAsync("/api/v1/budgets");
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement[0].GetProperty("period").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Test]
+    public async Task Delete_budgets_hides_it_from_the_collection()
+    {
+        var categoryId = await SeedCategoryReturningId();
+        await client.PostAsync("/api/v1/budgets", NewBudgetBody(categoryId, 30000, "Monthly"));
+
+        var deleted = await client.DeleteAsync("/api/v1/budgets/1");
+
+        deleted.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        using var document = JsonDocument.Parse(await (await client.GetAsync("/api/v1/budgets")).Content.ReadAsStringAsync());
+        document.RootElement.GetArrayLength().Should().Be(0);
+    }
+
+    /// <summary>
+    /// A budget on a category nobody can see measures nothing anyone can ask about. Without this,
+    /// the global query filter hides the category and budget reads meet a null one.
+    /// </summary>
+    [Test]
+    public async Task Delete_categories_also_deletes_the_budgets_pointing_at_it()
+    {
+        var categoryId = await SeedCategoryReturningId();
+        await client.PostAsync("/api/v1/budgets", NewBudgetBody(categoryId, 30000, "Monthly"));
+
+        var deleted = await client.DeleteAsync($"/api/v1/categories/{categoryId}");
+
+        deleted.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        var response = await client.GetAsync("/api/v1/budgets");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetArrayLength().Should().Be(0);
+    }
+
+    [Test]
+    public async Task Get_budgets_by_id_returns_a_problem_document_for_an_unknown_id()
+    {
+        var response = await client.GetAsync("/api/v1/budgets/404");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        response.Content.Headers.ContentType!.MediaType.Should().Be(ProblemJson);
     }
 
     // ---------------------------------------------------------------- error contract
@@ -902,6 +1134,28 @@ public class ApiEndpointTests
     private static StringContent NewTagBody(string label) =>
         JsonBody($"{{\"label\":\"{label}\",\"bgColorHex\":\"#ffffff\",\"fgColorHex\":\"#000000\"}}");
 
+    /// <summary>
+    /// Starts on the first of the current month so the budget is measuring today whatever day the
+    /// suite runs. A "None" recurrence deliberately gets no endsOn, which is what makes it invalid.
+    /// </summary>
+    private static StringContent NewBudgetBody(int categoryId, long minorUnits, string recurrence) =>
+        JsonBody(
+            $"{{\"categoryId\":{categoryId},\"amount\":{{\"minorUnits\":{minorUnits},\"currency\":\"EUR\"}},"
+            + $"\"recurrence\":\"{recurrence}\",\"startsOn\":\"{FirstOfThisMonth()}\"}}");
+
+    private static string FirstOfThisMonth()
+    {
+        var now = DateTime.UtcNow;
+        return new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc).ToString("yyyy-MM-dd");
+    }
+
+    /// <summary>
+    /// The ISO week year is not always the calendar year -- 2027-01-01 sits in week 53 of 2026 -- so
+    /// the expected name is built the same way the domain builds it.
+    /// </summary>
+    private static string IsoWeekName(DateTime instant) =>
+        $"{System.Globalization.ISOWeek.GetYear(instant):0000}-W{System.Globalization.ISOWeek.GetWeekOfYear(instant):00}";
+
     private XpenseDbContext NewDbContext(out IServiceScope scope)
     {
         scope = factory.Services.CreateScope();
@@ -1014,6 +1268,93 @@ public class ApiEndpointTests
         static DateTimeOffset At(int hour) => new(2026, 7, 26, hour, 0, 0, TimeSpan.Zero);
     }
 
+    private async Task<int> SeedCategoryReturningId()
+    {
+        var dbContext = NewDbContext(out var scope);
+        using (scope)
+        {
+            var priority = new Priority { Label = "Normal", Weight = 1, CreatedAt = DateTime.UtcNow };
+            var category = new Category { Label = "Food", Priority = priority, CreatedAt = DateTime.UtcNow };
+            dbContext.AddRange(priority, category);
+            await dbContext.SaveChangesAsync();
+            return category.Id;
+        }
+    }
+
+    /// <summary>
+    /// One monthly EUR budget on Food, plus today's spending against it. Optionally spends the same
+    /// category in USD, and optionally adds income and a transfer that must not be counted.
+    /// </summary>
+    private async Task SeedBudgetWithTodaysExpense(
+        long limitMinorUnits,
+        long spentMinorUnits,
+        long alsoSpendUsd = 0,
+        bool alsoSeedIncomeAndTransfer = false)
+    {
+        var dbContext = NewDbContext(out var scope);
+        using (scope)
+        {
+            var now = DateTime.UtcNow;
+            var priority = new Priority { Label = "Normal", Weight = 1, CreatedAt = now };
+            var account = NewAccount(SourceNumber, "Cash", 0, isDefault: true);
+            var other = NewAccount(DestinationNumber, "Savings", 0);
+            var category = new Category { Label = "Food", Priority = priority, CreatedAt = now };
+            var merchant = new Merchant { Label = "Grocer", CreatedAt = now };
+            dbContext.AddRange(priority, account, other, category, merchant);
+            await dbContext.SaveChangesAsync();
+
+            dbContext.Budgets.Add(Budget.For(
+                category,
+                Money.OfMinorUnits(limitMinorUnits, Currency.EUR),
+                Recurrence.Monthly,
+                new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc),
+                endsOn: null));
+
+            dbContext.Transactions.Add(NewExpense(spentMinorUnits, now, account, category, merchant));
+
+            if (alsoSpendUsd > 0)
+                dbContext.Transactions.Add(
+                    NewExpense(alsoSpendUsd, now, account, category, merchant, Currency.USD));
+
+            if (alsoSeedIncomeAndTransfer)
+            {
+                dbContext.Transactions.Add(NewIncome(9999, now, account, category, merchant));
+                dbContext.Transactions.Add(new Transaction
+                {
+                    AmountMinorUnits = 5555,
+                    Currency = Currency.EUR,
+                    SourceAccount = account,
+                    DestinationAccount = other,
+                    Tags = [],
+                    OccurredAt = now,
+                    CreatedAt = now
+                });
+            }
+
+            await dbContext.SaveChangesAsync();
+        }
+    }
+
+    /// <summary>Same category, same day, two currencies -- the case that used to be added together.</summary>
+    private async Task SeedTodayExpensesInTwoCurrencies()
+    {
+        var dbContext = NewDbContext(out var scope);
+        using (scope)
+        {
+            var now = DateTime.UtcNow;
+            var priority = new Priority { Label = "Normal", Weight = 1, CreatedAt = now };
+            var account = NewAccount(SourceNumber, "Cash", 0, isDefault: true);
+            var category = new Category { Label = "Food", Priority = priority, CreatedAt = now };
+            var merchant = new Merchant { Label = "Grocer", CreatedAt = now };
+            dbContext.AddRange(priority, account, category, merchant);
+            await dbContext.SaveChangesAsync();
+
+            dbContext.Transactions.Add(NewExpense(1250, now, account, category, merchant));
+            dbContext.Transactions.Add(NewExpense(700, now, account, category, merchant, Currency.USD));
+            await dbContext.SaveChangesAsync();
+        }
+    }
+
     private async Task SeedTodayExpense(bool alsoSeedIncomeAndTransfer = false)
     {
         var dbContext = NewDbContext(out var scope);
@@ -1072,10 +1413,11 @@ public class ApiEndpointTests
         DateTimeOffset occurredAt,
         Account source,
         Category category,
-        Merchant merchant) => new()
+        Merchant merchant,
+        Currency currency = Currency.EUR) => new()
     {
         AmountMinorUnits = amountMinorUnits,
-        Currency = Currency.EUR,
+        Currency = currency,
         SourceAccount = source,
         Category = category,
         Merchant = merchant,

--- a/src/Xpense/Xpense.Tests/Unit/BudgetTests.cs
+++ b/src/Xpense/Xpense.Tests/Unit/BudgetTests.cs
@@ -1,0 +1,234 @@
+using FluentAssertions;
+using Xpense.Domain.Enums;
+using Xpense.Domain.Exceptions;
+using Xpense.Domain.ValueObjects;
+using Entities = Xpense.Domain.Entities;
+
+namespace Xpense.Tests.Unit;
+
+/// <summary>
+/// Period arithmetic and the budget's own invariants. No persistence, so these are genuine unit
+/// tests; what a budget actually measures against real transactions is covered by the integration
+/// suite.
+/// </summary>
+[TestFixture]
+public class BudgetTests
+{
+    // A Thursday, comfortably inside week 32 of 2026 and the month of August.
+    private static readonly DateTime InAugust = new(2026, 8, 6, 14, 0, 0, DateTimeKind.Utc);
+
+    [Test]
+    public void A_monthly_budget_measures_the_calendar_month_holding_the_instant()
+    {
+        var period = Monthly(startsOn: new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc)).PeriodOn(InAugust);
+
+        period.Should().NotBeNull();
+        period!.Name.Should().Be("2026-08");
+        period.From.Should().Be(new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc));
+        period.ToExclusive.Should().Be(new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc));
+    }
+
+    /// <summary>
+    /// A period runs to the start of the next one and no further, so the two never both claim an
+    /// instant and no instant falls between them.
+    /// </summary>
+    [Test]
+    public void A_period_excludes_its_end_and_includes_its_start()
+    {
+        var period = Monthly(new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc)).PeriodOn(InAugust)!;
+
+        period.Contains(new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc)).Should().BeTrue();
+        period.Contains(new DateTime(2026, 8, 31, 23, 59, 59, DateTimeKind.Utc)).Should().BeTrue();
+        period.Contains(new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc)).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The whole month, not the part after the budget began. Activity is decided by the period
+    /// overlapping the budget's life rather than by the instant being inside it -- otherwise asking
+    /// about the 3rd and asking about the 20th would give two different answers for one period.
+    /// </summary>
+    [Test]
+    public void A_monthly_budget_starting_mid_month_still_measures_the_whole_month()
+    {
+        var budget = Monthly(startsOn: new DateTime(2026, 8, 15, 0, 0, 0, DateTimeKind.Utc));
+
+        var fromBefore = budget.PeriodOn(new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc));
+        var fromAfter = budget.PeriodOn(new DateTime(2026, 8, 20, 0, 0, 0, DateTimeKind.Utc));
+
+        fromBefore.Should().NotBeNull();
+        fromBefore.Should().Be(fromAfter);
+        fromBefore!.From.Should().Be(new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Test]
+    public void A_weekly_budget_measures_the_iso_week_monday_to_monday()
+    {
+        var period = Weekly(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)).PeriodOn(InAugust);
+
+        period.Should().NotBeNull();
+        period!.Name.Should().Be("2026-W32");
+        period.From.DayOfWeek.Should().Be(DayOfWeek.Monday);
+        period.From.Should().Be(new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc));
+        period.ToExclusive.Should().Be(new DateTime(2026, 8, 10, 0, 0, 0, DateTimeKind.Utc));
+    }
+
+    /// <summary>
+    /// The ISO week year is not the calendar year at the boundary: 1 January 2027 belongs to week 53
+    /// of 2026. Naming it from the instant's year would produce 2027-W53, a week that does not exist.
+    /// </summary>
+    [Test]
+    public void A_weekly_period_is_named_by_its_iso_week_year_not_the_calendar_year()
+    {
+        var period = Weekly(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+            .PeriodOn(new DateTime(2027, 1, 1, 12, 0, 0, DateTimeKind.Utc));
+
+        period!.Name.Should().Be("2026-W53");
+    }
+
+    [Test]
+    public void A_yearly_budget_measures_the_calendar_year()
+    {
+        var period = Yearly(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)).PeriodOn(InAugust);
+
+        period!.Name.Should().Be("2026");
+        period.From.Should().Be(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        period.ToExclusive.Should().Be(new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Test]
+    public void A_repeating_budget_measures_nothing_before_it_starts()
+    {
+        var budget = Monthly(startsOn: new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        budget.PeriodOn(new DateTime(2026, 7, 15, 0, 0, 0, DateTimeKind.Utc)).Should().BeNull();
+    }
+
+    [Test]
+    public void A_repeating_budget_measures_nothing_after_it_ends()
+    {
+        var budget = Entities.Budget.For(
+            Category(),
+            Money.OfMinorUnits(30000),
+            Recurrence.Monthly,
+            new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 8, 31, 0, 0, 0, DateTimeKind.Utc));
+
+        budget.PeriodOn(InAugust).Should().NotBeNull();
+        budget.PeriodOn(new DateTime(2026, 9, 2, 0, 0, 0, DateTimeKind.Utc)).Should().BeNull();
+    }
+
+    /// <summary>
+    /// A one-off has one window, which is its own dates rather than any calendar period, and it is
+    /// named by them. Its end date is inclusive, so the last day still counts.
+    /// </summary>
+    [Test]
+    public void A_one_off_budget_measures_its_own_window_and_nothing_outside_it()
+    {
+        var budget = Entities.Budget.For(
+            Category(),
+            Money.OfMinorUnits(20000),
+            Recurrence.None,
+            new DateTime(2026, 8, 12, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 8, 26, 0, 0, 0, DateTimeKind.Utc));
+
+        var period = budget.PeriodOn(new DateTime(2026, 8, 26, 23, 0, 0, DateTimeKind.Utc));
+
+        period.Should().NotBeNull();
+        period!.Name.Should().Be("2026-08-12..2026-08-26");
+        period.ToExclusive.Should().Be(new DateTime(2026, 8, 27, 0, 0, 0, DateTimeKind.Utc));
+        budget.PeriodOn(new DateTime(2026, 8, 11, 23, 0, 0, DateTimeKind.Utc)).Should().BeNull();
+        budget.PeriodOn(new DateTime(2026, 8, 27, 0, 0, 0, DateTimeKind.Utc)).Should().BeNull();
+    }
+
+    [Test]
+    public void A_budget_that_does_not_repeat_must_state_when_it_ends()
+    {
+        var act = () => Entities.Budget.For(
+            Category(), Money.OfMinorUnits(20000), Recurrence.None, InAugust, endsOn: null);
+
+        act.Should().Throw<InvalidBudgetException>().WithMessage("*must state when it ends*");
+    }
+
+    [Test]
+    public void A_budget_cannot_end_before_it_starts()
+    {
+        var act = () => Entities.Budget.For(
+            Category(),
+            Money.OfMinorUnits(20000),
+            Recurrence.Monthly,
+            new DateTime(2026, 8, 10, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        act.Should().Throw<InvalidBudgetException>().WithMessage("*cannot end before it starts*");
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void A_budget_amount_must_be_positive(long minorUnits)
+    {
+        var act = () => Monthly(InAugust, minorUnits);
+
+        act.Should().Throw<InvalidBudgetException>().WithMessage("*must be positive*");
+    }
+
+    /// <summary>
+    /// The dates are dates. A budget starts on a day, so any time of day handed in is dropped rather
+    /// than kept to surprise a later comparison.
+    /// </summary>
+    [Test]
+    public void A_budget_keeps_only_the_date_part_of_its_window()
+    {
+        var budget = Monthly(startsOn: new DateTime(2026, 8, 15, 17, 45, 12, DateTimeKind.Utc));
+
+        budget.StartsOn.Should().Be(new DateTime(2026, 8, 15, 0, 0, 0, DateTimeKind.Utc));
+        budget.StartsOn.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    [Test]
+    public void Restating_a_budget_applies_the_same_rules_as_creating_one()
+    {
+        var budget = Monthly(new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        var act = () => budget.Restate(Money.OfMinorUnits(500), Recurrence.None, InAugust, endsOn: null);
+
+        act.Should().Throw<InvalidBudgetException>().WithMessage("*must state when it ends*");
+        budget.AmountMinorUnits.Should().Be(30000, "a rejected restatement must not half-apply");
+    }
+
+    [Test]
+    public void Restating_a_budget_replaces_its_limit_and_window_and_touches_it()
+    {
+        var budget = Monthly(new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        budget.Restate(
+            Money.OfMinorUnits(50000, Currency.USD),
+            Recurrence.Yearly,
+            new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            endsOn: null);
+
+        budget.AmountMinorUnits.Should().Be(50000);
+        budget.Currency.Should().Be(Currency.USD);
+        budget.Recurrence.Should().Be(Recurrence.Yearly);
+        budget.StartsOn.Should().Be(new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        budget.UpdatedAt.Should().NotBeNull();
+    }
+
+    private static Entities.Budget Monthly(DateTime startsOn, long minorUnits = 30000) =>
+        Entities.Budget.For(
+            Category(), Money.OfMinorUnits(minorUnits), Recurrence.Monthly, startsOn, endsOn: null);
+
+    private static Entities.Budget Weekly(DateTime startsOn) =>
+        Entities.Budget.For(
+            Category(), Money.OfMinorUnits(10000), Recurrence.Weekly, startsOn, endsOn: null);
+
+    private static Entities.Budget Yearly(DateTime startsOn) =>
+        Entities.Budget.For(
+            Category(), Money.OfMinorUnits(500000), Recurrence.Yearly, startsOn, endsOn: null);
+
+    private static Entities.Category Category() => new()
+    {
+        Label = "Food",
+        Priority = new Entities.Priority { Label = "Normal", Weight = 1, CreatedAt = DateTime.UtcNow },
+        CreatedAt = DateTime.UtcNow
+    };
+}


### PR DESCRIPTION
A **Budget** is an intended limit on **Expense** for one **Category**, in one **Currency**, over a period. Five slices under `Features/Budgets`, one entity, one migration. The language was settled first — see the new Budgeting section in `UBIQUITOUS_LANGUAGE.md`.

```
Budgets
Id  CategoryId  Amount  Currency  Recurrence  StartsOn     EndsOn
1   3           30000   EUR       Monthly     2026-08-01   null
2   3           20000   EUR       None        2026-08-12   2026-08-26
3   3           15000   USD       Weekly      2026-08-01   null
```

All three coexist on one category. Nothing reconciles them, because nothing needs to.

## Two decisions carry the design

Both are ADRs, because without them the code reads as if something is missing.

**[ADR 0006](docs/adr/0006-a-budget-reports-and-never-blocks.md) — a Budget reports and never blocks.** Nothing consults a budget when a transaction is recorded. Xpense records money that has already moved, so refusing the record would not un-spend anything — it would only make Xpense disagree with the bank. Detecting a crossing belongs to the planned notification consumer, which reads a `TransactionRecorded` event and decides for itself what is noteworthy. **Budget never touches the write path**, so `Transaction` keeps its invariants and `CreateTransaction` its current cost.

**[ADR 0007](docs/adr/0007-budgets-are-independent-of-one-another.md) — Budgets are independent.** Nothing rejects two budgets covering one category, and there is no precedence rule. **Spent** and **Remaining** belong to a budget rather than to a category, so each answers only for itself. That is what makes a weekly guard under a monthly ceiling, and a holiday window beside a monthly plan, both expressible without arbitration.

## The rest of the model

- **One entity for both shapes**, differing only by `Recurrence`. A second entity for the other shape is the mistake [ADR 0001](docs/adr/0001-one-transaction-entity-with-two-nullable-sides.md) corrected once.
- **Named periods.** Repeating budgets measure calendar weeks, months and years, so each period has a name — `2026-W32`, `2026-08`, `2026` — that a client, a report and a notification can all mean the same thing by.
- **Only Expenses count.** A **Transfer** has no **Category** and is money you still own; **Income** is not spending. Measured by **Occurred at**, like all reporting.
- **One currency per Budget**, with spending in others reported as explicitly `uncounted`. Money that vanishes from a report is worse than money listed as not counted.
- **A monthly budget starting mid-month measures the whole month.** Activity is decided by the period overlapping the budget's life, not by the instant being inside it — otherwise asking about the 3rd and the 20th would report two different totals for one period.
- **Deleting a Category soft-deletes its Budgets.** The global query filter hides the category, so a surviving budget would load with a null one.
- Reads compute for the period holding today, or `?on=<date>`. `ListBudgets` fetches every budget's spending in one grouped query rather than one per budget; `GetBudgetById` groups in the database instead, since a single budget has a single window.

## Three adjacent fixes riding along

- **`GetSpendingByCategory` invented money.** It summed minor units across currencies and labelled the total with the first expense's, so 12.50 EUR and 7.00 USD reported as **19.50 EUR**. Now grouped by currency, one total per currency present. This is a breaking response change: `total` becomes `totals`.
- **`ListPriorities`.** A category requires a priority id and nothing exposed them, so a client had to hardcode 1 to 5.
- **`Money.Zero` is EUR**, so a budget in another currency needs its zero built explicitly — subtracting a EUR zero from a USD limit throws.

## Verified

105 tests pass, 29 new, build warning-free. Unit tests cover the period arithmetic, including the ISO week boundary where 2027-01-01 belongs to week 53 of 2026.

Also checked over HTTP against the containerized stack, not only in process — the migration applies and the answers are right:

| Request | Result |
|---|---|
| `GET /api/v1/priorities` | the five seeded rows, Extreme first |
| `GET /api/v1/budgets` | period `2026-08`, spent `1250 EUR`, remaining `28750 EUR`, exceeded false |
| after a `700 USD` expense on the same category | `uncounted: [{700, USD}]`, spent unchanged |
| `?on=2026-09-15` | period `2026-09`, spent `0 EUR`, remaining `30000 EUR` |
| `?on=2020-01-01` | `period: null` — before it starts |
| `GET /api/v1/analytics/spending/by-category` | `1250 EUR` and `700 USD` separately, never `1950 EUR` |

## Not in this epic

No authentication. Notifications and the message queue are their own epic — this PR deliberately raises no events and stores no crossings, so that epic can choose its own event contract.