### PR TITLE
fix: unique schema ids so the OpenAPI document generates

### DIFF
--- a/src/Xpense/Xpense.API/Extensions/IoC.cs
+++ b/src/Xpense/Xpense.API/Extensions/IoC.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Xpense.API.ExceptionHandlers;
@@ -72,6 +73,8 @@ public static class IoC
     {
         services.AddSwaggerGen(options =>
         {
+            options.CustomSchemaIds(SchemaId);
+
             options.SwaggerDoc(
                 "v1",
                 new OpenApiInfo
@@ -92,5 +95,20 @@ public static class IoC
             var xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
             options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename));
         });
+    }
+
+    /// <summary>
+    /// A schema id that is unique for a nested type: every name it is declared inside, outermost first,
+    /// then its own. <c>CreateBudget.Request</c> becomes <c>CreateBudgetRequest</c>.
+    /// </summary>
+    private static string SchemaId(Type type)
+    {
+        var names = new List<string>();
+
+        for (var current = type; current is not null; current = current.DeclaringType)
+            names.Insert(0, current.Name);
+
+        // Generics arrive as `Thing`1`; the arity suffix is not valid in a schema id.
+        return string.Concat(names).Replace("`", string.Empty);
     }
 }


### PR DESCRIPTION
`GET /swagger/v1/swagger.json` returns **500**, so Swagger UI is broken — and [ADR 0003](docs/adr/0003-generated-openapi-is-the-contract.md) declares that generated document to be *the* API contract.

## Cause

The slice convention meeting a Swashbuckle default. Every slice nests its request as `Request` (per `AGENTS.md`), and the default schema id is the bare type name, so the second slice generated collides with the first:

```
Can't use schemaId "$Request" for type "...Budgets.CreateBudget+Request".
The same schemaId is already used for "...Accounts.CreateAccount+Request"
```

Broken since the vertical-slice migration.

## Fix

`CustomSchemaIds` qualifies a nested type with every name it is declared inside, so `CreateBudget.Request` becomes `CreateBudgetRequest`.

## Verified

Build clean, 0 warnings. `swagger.json` returns a real document with all paths and 33 schemas, where before it returned a ProblemDetails 500.

One file. This is the first of a stack that splits an over-large branch into reviewable pieces; the rest follow on top.