### PR TITLE
fix: exception handlers logged to Serilog's silent default

### DIFF
--- a/src/Xpense/Xpense.API/Program.cs
+++ b/src/Xpense/Xpense.API/Program.cs
@@ -17,7 +17,7 @@ builder.Host.UseSerilog((context, services, configuration) =>
         .WriteTo.Console();
 });
 
-builder.Services.AddSingleton(Log.Logger);
+builder.Services.AddSingleton<Serilog.ILogger>(_ => Log.Logger);
 // AddControllers used to bring these in implicitly; without MVC they must be explicit.
 builder.Services.AddCors();
 builder.Services.AddEndpointsApiExplorer();


### PR DESCRIPTION
Every unhandled exception was logged to nowhere, so a 500 left no trace.

## Cause

```csharp
builder.Services.AddSingleton(Log.Logger);
```

That evaluates `Log.Logger` at that line — which runs *before* `UseSerilog` configures it. The container captured Serilog's silent default, so every `logger.Error(...)` in the exception handlers wrote into a void.

## Fix

A factory, so the lookup is deferred until after the host is built and `UseSerilog` has assigned the configured logger.

```csharp
builder.Services.AddSingleton<Serilog.ILogger>(_ => Log.Logger);
```

## Verified

Forced a 500 by posting a duplicate category label. The log now shows:

```
[ERR] Unhandled exception handling POST /api/v1/categories
...
duplicate key value violates unique constraint "IX_Categories_Label"
```

Before this, nothing was written — the response body was the only evidence the request had failed. This is also what hid the Swagger bug in the PR below.

One file. Stacked on #48; **base is `fix/swagger-schema-ids`**, so merge that one first.