### PR TITLE
chore: restore from nuget.org only

### DIFF
--- a/src/Xpense/nuget.config
+++ b/src/Xpense/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Every build reported `NU1900` four times, once per project:

```
Unable to load the service index for source
https://code-artifact.tooling.aws.cool.blue/nuget/v3/index.json
```

That is a private feed configured at machine level, inherited by every restore in this repository — which never wanted it, and cannot reach it off that network.

A committed `nuget.config` clears inherited sources and pins nuget.org. The warning goes away because the cause does, rather than by suppressing the code, and a restore now resolves the same packages wherever it runs instead of depending on whose machine it is.

## Verified

Clean build from a wiped `obj/` and `bin/`: **0 warnings, 0 errors**. Previously 8.

One file. Stacked; **base is `fix/exception-logging`** (#49).