### PR TITLE
refactor: validation messages read as prose, not identifiers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,3 @@
-# The build context is the repository root, so this file is what keeps it to source. Host bin/obj
-# are the important entries: copying them in is slow and can leave stale assemblies in the publish
-# output, which is the kind of bug that only reproduces inside the image.
 **/bin/
 **/obj/
 
@@ -11,7 +8,6 @@
 .idea/
 .worktrees/
 
-# Never let a secret into the build context.
 .env
 
 docs/

--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,2 @@
-# Copy to .env before the first `docker compose up`:
-#
-#   cp .env.example .env
-#
-# Compose deliberately defines no fallback for POSTGRES_PASSWORD, so a missing .env aborts with a
-# message naming this file rather than starting a database with a password anyone could guess.
 POSTGRES_PASSWORD=change-me
-
-# How many days of dumps docker/postgres/backup.sh keeps. Optional; defaults to 14.
-#BACKUP_RETAIN_DAYS=14
+BACKUP_RETAIN_DAYS=14

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,20 +1,12 @@
-# This workflow will build a .NET project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
-
 name: .NET
 
 on:
   push:
     branches: [ "main" ]
-  # Every branch, not just those targeting main. Stacked pull requests are based on
-  # their parent branch, so a main-only filter silently skips CI for all but the
-  # bottom of a stack.
   pull_request:
     branches: [ "**" ]
 
 env:
-  # The solution lives under src/Xpense, not the repository root. Without this every
-  # dotnet command failed with MSB1003.
   SOLUTION: src/Xpense/Xpense.sln
 
 jobs:
@@ -32,8 +24,6 @@ jobs:
       run: dotnet restore $SOLUTION
     - name: Build
       run: dotnet build $SOLUTION --no-restore
-    # Integration tests start a real PostgreSQL container via Testcontainers.
-    # ubuntu-latest ships a running Docker daemon, so no service container is needed.
     - name: Test
       run: >
         dotnet test $SOLUTION --no-build
@@ -49,18 +39,11 @@ jobs:
           -targetdir:CoverageReport \
           -reporttypes:'MarkdownSummaryGithub;Html'
         cat CoverageReport/SummaryGithub.md >> "$GITHUB_STEP_SUMMARY"
-    # The inner dev loop runs the API on the host, so nothing there exercises the images. This step
-    # is the compensating check: it builds them and boots the whole stack. The class of bug it
-    # catches is the one that built fine and died on first container boot -- a seeder reading a file
-    # `dotnet publish` never copied, a connection string pointing at localhost from inside a
-    # container, migrations that never ran.
     - name: Smoke-test the compose stack
       run: |
         cp .env.example .env
         sed -i 's/^POSTGRES_PASSWORD=.*/POSTGRES_PASSWORD=ci-not-a-secret/' .env
         docker compose up -d --build
-        # Poll rather than `--wait`: the migrations service exits by design, and polling the health
-        # endpoint asserts the thing we actually care about.
         curl -fsS --retry 30 --retry-delay 2 --retry-all-errors http://localhost:4000/health
     - name: Compose logs
       if: ${{ !cancelled() }}

--- a/.gitignore
+++ b/.gitignore
@@ -406,7 +406,5 @@ CoverageReport/
 # macOS
 .DS_Store
 
-# Docker: the compose password lives here, and pg_dump output lands here. Neither belongs in git.
-# `Backup*/` above does not match lowercase `backups/`.
 .env
 backups/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,10 @@ These are enforced by `Xpense.Tests/Architecture/SliceIsolationTests.cs`. Breaki
 
 `GET /health` is the one deliberate exception: it is mapped directly in `Program.cs` because it is infrastructure, not a feature. It has no request, no contract to version and no slice to belong to. The architecture tests allow it — they constrain types under `Xpense.API.Features.*` and types implementing `IEndpoint`, and it is neither. Do not treat it as precedent for a second one.
 
+## Style
+
+- **Validation messages are prose, not identifiers.** "The category must be a valid selection", never "The categoryId must reference an existing category". The ProblemDetails error dictionary is already keyed by the camelCase field, which is how a client attaches an error to an input, so the message is free to read like a sentence. Domain words stay: "minor units" is the term, per [`UBIQUITOUS_LANGUAGE.md`](UBIQUITOUS_LANGUAGE.md).
+
 ## Conventions
 
 - **Requests nest inside their slice** (`CreateTag.Request`), even when two look alike today. Responses are shared per feature or in `Contracts/`, because a resource should look the same however you fetched it.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,5 @@
-# Pinned rather than derived from the directory name, so renaming or re-cloning the checkout cannot
-# silently point compose at a different set of volumes. The value matches what the directory already
-# produced -- changing it would orphan the existing xpenseapi_xpense-postgres-data volume, and the
-# local database with it.
 name: xpenseapi
 
-# One connection string, referenced by the two services that need it. The `:?` form has no default
-# on purpose: a missing password aborts the command with this message instead of starting something
-# with a guessable one. Same principle as appsettings.json shipping no connection string.
 x-connection: &connection "Host=postgres;Port=5432;Database=xpense;Username=xpense;Password=${POSTGRES_PASSWORD:?missing - copy .env.example to .env}"
 
 services:
@@ -21,21 +14,16 @@ services:
       POSTGRES_USER: xpense
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?missing - copy .env.example to .env}
     ports:
-      # Loopback only. Plain "5432:5432" would publish Postgres on every interface, which is more
-      # than the host loop and Testcontainers need.
       - "127.0.0.1:5432:5432"
     volumes:
       - xpense-postgres-data:/var/lib/postgresql/data
-      # Backups live outside the data volume so losing the volume does not lose them too.
       - ./backups:/backups
     healthcheck:
-      # `dotnet run` right after `compose up` otherwise races the database's first start.
       test: ["CMD-SHELL", "pg_isready -U xpense -d xpense"]
       interval: 5s
       timeout: 5s
       retries: 10
 
-  # Applies migrations, then exits. Not a server -- `docker compose ps` showing it gone is success.
   migrations:
     build:
       context: .
@@ -55,23 +43,15 @@ services:
     container_name: xpense-api
     restart: unless-stopped
     depends_on:
-      # Starts only once migrations has exited 0, so the schema always exists first. Note this gate
-      # applies to `compose up`; after a Docker daemon restart the restart policy can bring this
-      # back on its own, against whatever schema is already there.
       migrations:
         condition: service_completed_successfully
     environment:
-      # Development so Swagger UI is served. This env var outranks appsettings.Development.json,
-      # so its hardcoded Host=localhost is overridden rather than needing an edit.
       ASPNETCORE_ENVIRONMENT: Development
       ASPNETCORE_HTTP_PORTS: 8080
       ConnectionStrings__DefaultConnection: *connection
     ports:
-      # 4000 to match the port the host loop already uses, so only one of the two runs at a time.
       - "127.0.0.1:4000:8080"
     healthcheck:
-      # BusyBox wget, present in the Alpine base. A red healthcheck restarts nothing by itself --
-      # it is here so `docker compose ps` and `--wait` tell the truth.
       test: ["CMD-SHELL", "wget -qO- http://localhost:8080/health || exit 1"]
       interval: 10s
       timeout: 3s

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,12 +1,5 @@
 # syntax=docker/dockerfile:1
 
-# The build context is the repository root, not this directory -- the build needs the whole
-# solution. Compose passes `context: .` with `dockerfile: docker/api/Dockerfile`.
-#
-# The stanza up to `dotnet restore` is byte-identical to docker/migrations/Dockerfile on purpose.
-# BuildKit keys its cache on layer content rather than on which Dockerfile produced it, so the
-# second image reuses this restore instead of repeating it. Keep the two in step: if they drift,
-# the builds still work, they just quietly stop sharing and get slower.
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
@@ -23,12 +16,10 @@ RUN dotnet publish Xpense.API/Xpense.API.csproj -c Release -o /app --no-restore
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS final
 WORKDIR /app
 
-# Nothing in this image writes to disk or binds a privileged port, so it has no reason to be root.
 RUN adduser -D -u 1001 xpense
 USER xpense
 
 COPY --from=build /app ./
 
-# Kestrel binds 8080 inside; compose publishes it on the host as 4000.
 EXPOSE 8080
 ENTRYPOINT ["dotnet", "Xpense.API.dll"]

--- a/docker/migrations/Dockerfile
+++ b/docker/migrations/Dockerfile
@@ -1,10 +1,5 @@
 # syntax=docker/dockerfile:1
 
-# Applies migrations and exits. Runs as its own deployment step so no application instance ever
-# migrates itself -- see docs/adr/0004-migrations-are-a-deployment-step.md.
-#
-# The stanza up to `dotnet restore` is byte-identical to docker/api/Dockerfile on purpose; see the
-# note there about the shared BuildKit cache.
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
@@ -17,14 +12,6 @@ RUN dotnet restore Xpense.sln
 
 COPY src/Xpense/ ./
 
-# `dotnet ef` comes from .config/dotnet-tools.json, so the manifest is the single place the version
-# is pinned -- the same one used to scaffold migrations locally.
-#
-# The bundle is self-contained: the runtime is inside the binary, so the final image needs no SDK,
-# no .NET runtime and no source tree. That means naming a target runtime, and it has to follow the
-# architecture actually being built for -- a hardcoded x64 RID produces a binary that dies on an
-# Apple Silicon machine with "failed to open elf at /lib/ld-musl-x86_64.so.1". TARGETARCH is
-# supplied by BuildKit; musl rather than glibc because the final image is Alpine-based.
 ARG TARGETARCH
 RUN case "${TARGETARCH}" in \
       amd64) rid=linux-musl-x64 ;; \
@@ -39,8 +26,6 @@ RUN case "${TARGETARCH}" in \
       --self-contained --target-runtime "${rid}" \
       --output /app/efbundle
 
-# runtime-deps, not runtime: a self-contained binary carries its own .NET but still needs the
-# native libraries (libstdc++, ICU) that this image exists to provide.
 FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-alpine AS final
 WORKDIR /app
 
@@ -49,6 +34,4 @@ USER xpense
 
 COPY --from=build /app/efbundle ./efbundle
 
-# Compose appends `--connection <string>`. XpenseContextFactory hardcodes Host=localhost for
-# design time, which inside a container means this container, so the value is always passed in.
 ENTRYPOINT ["./efbundle"]

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,12 +1,9 @@
 # syntax=docker/dockerfile:1
 
-# Build context is this directory, since nothing here needs the solution.
 FROM postgres:17-alpine
 
 COPY postgresql.conf /etc/postgresql/postgresql.conf
 COPY backup.sh /usr/local/bin/backup.sh
 RUN chmod +x /usr/local/bin/backup.sh
 
-# The official entrypoint still runs (initdb, POSTGRES_* handling); only the server command is
-# replaced, which is the documented way to point Postgres at a config file of your own.
 CMD ["postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"]

--- a/docker/postgres/backup.sh
+++ b/docker/postgres/backup.sh
@@ -1,24 +1,14 @@
 #!/bin/sh
-# Dumps the database to /backups, which is a bind mount from the host -- deliberately not the data
-# volume, so a corrupted volume does not take the backups with it.
-#
-# Nothing calls this on a schedule from inside the container. Add a host crontab line:
-#   0 3 * * *  cd /path/to/Xpense.API && docker compose exec -T postgres backup.sh
-#
-# See docs/docker.md for the restore drill. A backup nobody has restored is a guess.
 set -eu
 
 BACKUP_DIR=${BACKUP_DIR:-/backups}
 RETAIN_DAYS=${BACKUP_RETAIN_DAYS:-14}
 
-# -Fc is the custom format: compressed, and pg_restore can pull a single table out of it rather
-# than forcing an all-or-nothing replay.
 stamp=$(date -u +%Y%m%dT%H%M%SZ)
 out="${BACKUP_DIR}/xpense-${stamp}.dump"
 
 pg_dump -Fc -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -f "${out}"
 
-# Prune after a successful dump, never before -- a failing pg_dump must not also delete history.
 find "${BACKUP_DIR}" -name 'xpense-*.dump' -type f -mtime "+${RETAIN_DAYS}" -delete
 
 echo "backup: ${out} ($(du -h "${out}" | cut -f1))"

--- a/docker/postgres/postgresql.conf
+++ b/docker/postgres/postgresql.conf
@@ -1,29 +1,17 @@
-# Overrides only. Every setting Postgres knows has a compiled-in default, so this file does not
-# need to be a full copy of the upstream sample -- but three settings have to be here anyway,
-# because pointing `config_file` outside PGDATA changes where Postgres looks for them.
 
-# Without this, the compiled-in default is 'localhost', which for a container means "nothing
-# outside me can connect" -- the api container would fail with no obvious reason why.
 listen_addresses = '*'
 
-# These default to the directory holding config_file, i.e. /etc/postgresql, where they do not
-# exist. Postgres refuses to start rather than guessing. The real files are the ones initdb wrote.
 hba_file = '/var/lib/postgresql/data/pg_hba.conf'
 ident_file = '/var/lib/postgresql/data/pg_ident.conf'
 
-# Sized for a development machine, not a server: small enough to be polite about RAM, large enough
-# that a few thousand transactions do not thrash. Revisit if this ever runs somewhere real.
 shared_buffers = 256MB
 effective_cache_size = 768MB
 work_mem = 8MB
 maintenance_work_mem = 128MB
 
-# Query statistics, so "which query is slow" is answerable when it matters instead of guessable.
-# The extension still needs CREATE EXTENSION pg_stat_statements in the database to expose its view.
 shared_preload_libraries = 'pg_stat_statements'
 pg_stat_statements.track = all
 
-# Log anything slower than a second. Silent by default otherwise.
 log_min_duration_statement = 1000
 log_timezone = 'UTC'
 timezone = 'UTC'

--- a/src/Xpense/Xpense.API/Features/Budgets/CreateBudget.cs
+++ b/src/Xpense/Xpense.API/Features/Budgets/CreateBudget.cs
@@ -37,7 +37,7 @@ public sealed class CreateBudget : IEndpoint
         public Validator()
         {
             RuleFor(request => request.CategoryId)
-                .GreaterThan(0).WithMessage("The categoryId must reference an existing category.");
+                .GreaterThan(0).WithMessage("The category must be a valid selection.");
 
             RuleFor(request => request.Amount)
                 .NotNull().WithMessage("The amount is required.");
@@ -66,7 +66,7 @@ public sealed class CreateBudget : IEndpoint
 
             RuleFor(request => request.EndsOn)
                 .Must((request, endsOn) => endsOn is null || endsOn >= request.StartsOn)
-                .WithMessage("The endsOn date cannot be before startsOn.");
+                .WithMessage("The end date cannot be before the start date.");
         }
 
         private static bool IsOneOff(string recurrence) =>

--- a/src/Xpense/Xpense.API/Features/Budgets/UpdateBudget.cs
+++ b/src/Xpense/Xpense.API/Features/Budgets/UpdateBudget.cs
@@ -57,7 +57,7 @@ public sealed class UpdateBudget : IEndpoint
 
             RuleFor(request => request.EndsOn)
                 .Must((request, endsOn) => endsOn is null || endsOn >= request.StartsOn)
-                .WithMessage("The endsOn date cannot be before startsOn.");
+                .WithMessage("The end date cannot be before the start date.");
         }
 
         private static bool IsOneOff(string recurrence) =>

--- a/src/Xpense/Xpense.API/Features/Categories/CreateCategory.cs
+++ b/src/Xpense/Xpense.API/Features/Categories/CreateCategory.cs
@@ -28,7 +28,7 @@ public sealed class CreateCategory : IEndpoint
                 .MaximumLength(200);
 
             RuleFor(request => request.PriorityId)
-                .GreaterThan(0).WithMessage("The priorityId must reference an existing priority.");
+                .GreaterThan(0).WithMessage("The priority must be a valid selection.");
         }
     }
 

--- a/src/Xpense/Xpense.API/Features/Categories/UpdateCategory.cs
+++ b/src/Xpense/Xpense.API/Features/Categories/UpdateCategory.cs
@@ -26,7 +26,7 @@ public sealed class UpdateCategory : IEndpoint
                 .MaximumLength(200);
 
             RuleFor(request => request.PriorityId)
-                .GreaterThan(0).WithMessage("The priorityId must reference an existing priority.");
+                .GreaterThan(0).WithMessage("The priority must be a valid selection.");
         }
     }
 

--- a/src/Xpense/Xpense.API/Features/Tags/CreateTag.cs
+++ b/src/Xpense/Xpense.API/Features/Tags/CreateTag.cs
@@ -25,8 +25,8 @@ public sealed class CreateTag : IEndpoint
                 .NotEmpty().WithMessage("The label is required.")
                 .MaximumLength(100);
 
-            RuleFor(request => request.BgColorHex).HexColour("bgColorHex");
-            RuleFor(request => request.FgColorHex).HexColour("fgColorHex");
+            RuleFor(request => request.BgColorHex).HexColour("background colour");
+            RuleFor(request => request.FgColorHex).HexColour("foreground colour");
         }
     }
 

--- a/src/Xpense/Xpense.API/Features/Tags/UpdateTag.cs
+++ b/src/Xpense/Xpense.API/Features/Tags/UpdateTag.cs
@@ -24,8 +24,8 @@ public sealed class UpdateTag : IEndpoint
                 .NotEmpty().WithMessage("The label is required.")
                 .MaximumLength(100);
 
-            RuleFor(request => request.BgColorHex).HexColour("bgColorHex");
-            RuleFor(request => request.FgColorHex).HexColour("fgColorHex");
+            RuleFor(request => request.BgColorHex).HexColour("background colour");
+            RuleFor(request => request.FgColorHex).HexColour("foreground colour");
         }
     }
 

--- a/src/Xpense/Xpense.API/Features/Transactions/CreateTransaction.cs
+++ b/src/Xpense/Xpense.API/Features/Transactions/CreateTransaction.cs
@@ -65,7 +65,7 @@ public sealed class CreateTransaction : IEndpoint
             RuleFor(request => request)
                 .Must(request => Names(request.SourceAccountNumber) || Names(request.DestinationAccountNumber))
                 .WithMessage(
-                    "At least one of sourceAccountNumber and destinationAccountNumber is required.")
+                    "Either a source account or a destination account is required.")
                 .WithName(nameof(Request.SourceAccountNumber));
 
             // A transaction with one account inside Xpense has a counterparty outside it, which the
@@ -73,8 +73,8 @@ public sealed class CreateTransaction : IEndpoint
             When(IsOneSided, () =>
             {
                 RuleFor(request => request.CategoryId)
-                    .NotNull().WithMessage("The categoryId is required unless both accounts are named.")
-                    .GreaterThan(0).WithMessage("The categoryId must reference an existing category.");
+                    .NotNull().WithMessage("A category is required unless both accounts are named.")
+                    .GreaterThan(0).WithMessage("The category must be a valid selection.");
 
                 RuleFor(request => request.Merchant)
                     .NotNull().WithMessage("The merchant is required unless both accounts are named.");

--- a/src/Xpense/Xpense.API/Xpense.API.csproj
+++ b/src/Xpense/Xpense.API/Xpense.API.csproj
@@ -2,22 +2,15 @@
 
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
-		<!-- "annotations" lets DTOs use `?` without turning on the full null-flow analysis,
-		     which the rest of this project is not yet clean under. -->
 		<Nullable>annotations</Nullable>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<!--TODO: Remove the below warning once stabilized-->
 		<NoWarn>$(NoWarn);1591</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<!-- No MVC. Slices are minimal-API endpoints, and API versioning lives in the
-		     route path (/api/v1/...) rather than in Asp.Versioning. -->
 		<PackageReference Include="FluentValidation" Version="12.1.1" />
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-		<!-- /health reports whether the API can reach Postgres, which is the only thing worth
-		     asking. AddDbContextCheck lives in this package, not in the framework. -->
 		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.10" />
 		<PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />

--- a/src/Xpense/Xpense.Domain/Xpense.Domain.csproj
+++ b/src/Xpense/Xpense.Domain/Xpense.Domain.csproj
@@ -9,7 +9,4 @@
   <ItemGroup>
   </ItemGroup>
 
-  <!-- System.Linq.Async removed: net10 ships System.Linq.AsyncEnumerable in the BCL and the
-       package's extension methods now collide with it. -->
-
 </Project>

--- a/src/Xpense/Xpense.Persistence/Xpense.Persistence.csproj
+++ b/src/Xpense/Xpense.Persistence/Xpense.Persistence.csproj
@@ -8,9 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
-    <!-- Npgsql floors EF at 10.0.4; without pinning Relational too, NuGet resolves it to
-         10.0.4 against a 10.0.10 core and the app fails at runtime with a missing
-         Microsoft.EntityFrameworkCore.Relational assembly. -->
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="10.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">

--- a/src/Xpense/Xpense.Tests/Xpense.Tests.csproj
+++ b/src/Xpense/Xpense.Tests/Xpense.Tests.csproj
@@ -10,19 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Pinned to 6.x on purpose: FluentAssertions 8 moved to a commercial Xceed licence.
-         6.12.0 is Apache-2.0 and runs fine on net10. -->
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Mono.Cecil" Version="0.11.6" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
-    <!-- Npgsql floors EF at 10.0.4; without pinning Relational too, NuGet resolves it to
-         10.0.4 against a 10.0.10 core and the app fails at runtime with a missing
-         Microsoft.EntityFrameworkCore.Relational assembly. -->
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.10" />
-    <!-- Integration tests run against a real Postgres container, not SQLite, so the
-         provider under test is the provider that ships. -->
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.13.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Moq.EntityFrameworkCore" Version="10.0.0.2" />


### PR DESCRIPTION
A client saw `"The categoryId must reference an existing category."` — a field identifier echoed into text meant for a person.

The identifier already has a home. The ProblemDetails `errors` dictionary is keyed by the camelCase field, which is how a client attaches an error to an input, so the message is free to be a sentence:

| Key (unchanged) | Before | After |
|---|---|---|
| `categoryId` | The categoryId must reference an existing category. | The category must be a valid selection. |
| `priorityId` | The priorityId must reference an existing priority. | The priority must be a valid selection. |
| `endsOn` | The endsOn date cannot be before startsOn. | The end date cannot be before the start date. |
| `sourceAccountNumber` | At least one of sourceAccountNumber and destinationAccountNumber is required. | Either a source account or a destination account is required. |
| `bgColorHex` | The bgColorHex must be a 3 or 6 digit hex colour… | The background colour must be a 3 or 6 digit hex colour… |

`TagRules.HexColour` now takes a display name rather than a field name, so its four call sites pass `"background colour"` / `"foreground colour"`.

## Deliberately kept

`"The amount in minor units must be positive."` — **minor units** is the term `UBIQUITOUS_LANGUAGE.md` mandates in code, in the database and on the wire, precisely because "cents" is wrong for the first currency without them. It is domain vocabulary, not a leaked identifier.

## Verified

Build clean, 105 tests pass. The error-contract tests assert keys and response shapes, both unchanged.

8 files. Stacked; **base is `chore/pin-nuget-sources`** (#50).