### PR TITLE
refactor: spell identifiers out

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,8 @@ These are enforced by `Xpense.Tests/Architecture/SliceIsolationTests.cs`. Breaki
 
 ## Style
 
+- **Spell names out.** `cancellationToken`, not `ct`. `dbContext`, not `db`. `httpContext`, not `http`. Lambda parameters are named for what they hold, and for *their own* type -- in relationship configuration the two sides differ, so `HasOne(transaction => transaction.Category).WithMany(category => category.Transactions)`. `app` in `Map(IEndpointRouteBuilder app)` is the one exception, being the framework's own name for that thing.
+- **Constants first.** `const` and `static readonly` go at the top of the type, before fields, properties and methods.
 - **Validation messages are prose, not identifiers.** "The category must be a valid selection", never "The categoryId must reference an existing category". The ProblemDetails error dictionary is already keyed by the camelCase field, which is how a client attaches an error to an input, so the message is free to read like a sentence. Domain words stay: "minor units" is the term, per [`UBIQUITOUS_LANGUAGE.md`](UBIQUITOUS_LANGUAGE.md).
 
 ## Conventions

--- a/docs/vertical-slicing-architecture/01-anatomy-of-a-slice.md
+++ b/docs/vertical-slicing-architecture/01-anatomy-of-a-slice.md
@@ -17,7 +17,7 @@ public sealed class CreateTag : IEndpoint
 
     // 4. The handler.
     private static async Task<Created<TagResponse>> Handle(
-        Request request, XpenseDbContext db, CancellationToken ct) { ... }
+        Request request, XpenseDbContext dbContext, CancellationToken cancellationToken) { ... }
 }
 ```
 

--- a/docs/vertical-slicing-architecture/03-what-stays-shared.md
+++ b/docs/vertical-slicing-architecture/03-what-stays-shared.md
@@ -18,18 +18,18 @@ The test: **if it would still be true with no HTTP layer at all, it is domain.**
 `CreateTransaction.cs` is the slice. It owns the route, the request, the validator, loading the accounts, category and merchant, and the atomic boundary:
 
 ```csharp
-await using var scope = await db.Database.BeginTransactionAsync(IsolationLevel.Serializable, ct);
+await using var scope = await dbContext.Database.BeginTransactionAsync(IsolationLevel.Serializable, cancellationToken);
 try
 {
     var transaction = source is not null && destination is not null
         ? Transaction.Transfer(source, destination, amount, request.Reason, tags, occurredAt)
         : await OneSided(...);   // Transaction.Income or Transaction.Expense
-    db.Transactions.Add(transaction);
-    await db.SaveChangesAsync(ct);
-    await scope.CommitAsync(ct);
+    dbContext.Transactions.Add(transaction);
+    await dbContext.SaveChangesAsync(cancellationToken);
+    await scope.CommitAsync(cancellationToken);
     ...
 }
-catch { await scope.RollbackAsync(ct); throw; }
+catch { await scope.RollbackAsync(cancellationToken); throw; }
 ```
 
 The three static factories on `Transaction` are the domain. Each enforces that the amount is positive and that the currencies agree; `Transfer` additionally enforces that the accounts differ and that the source can cover it. Then they move the balances and build the row. They have no EF dependency and no HTTP dependency, so their tests need neither — `TransactionTests` is a genuine unit test, unlike the SQLite-backed "unit" tests it replaced.

--- a/src/Xpense/Xpense.API/Features/Accounts/CreateAccount.cs
+++ b/src/Xpense/Xpense.API/Features/Accounts/CreateAccount.cs
@@ -57,9 +57,9 @@ public sealed class CreateAccount : IEndpoint
 
     private static async Task<Created<AccountResponse>> Handle(
         Request request,
-        XpenseDbContext db,
-        HttpContext http,
-        CancellationToken ct)
+        XpenseDbContext dbContext,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
     {
         CurrencyParser.TryParse(request.Balance.Currency, out var currency);
 
@@ -68,18 +68,18 @@ public sealed class CreateAccount : IEndpoint
             Label = request.Label,
             BalanceMinorUnits = request.Balance.MinorUnits,
             Currency = currency,
-            AccountNumber = await NextAccountNumber(db, ct),
-            IsDefault = !await db.Accounts.AnyAsync(a => a.IsDefault, ct),
+            AccountNumber = await NextAccountNumber(dbContext, cancellationToken),
+            IsDefault = !await dbContext.Accounts.AnyAsync(account => account.IsDefault, cancellationToken),
             CreatedAt = DateTime.UtcNow
         };
 
-        db.Accounts.Add(account);
+        dbContext.Accounts.Add(account);
 
-        if (await db.SaveChangesAsync(ct) < 1)
+        if (await dbContext.SaveChangesAsync(cancellationToken) < 1)
             throw new AccountCreationFailedException(request.Label);
 
         return TypedResults.Created(
-            http.ResourceUri($"/api/v1/accounts/{account.AccountNumber}"),
+            httpContext.ResourceUri($"/api/v1/accounts/{account.AccountNumber}"),
             AccountResponse.Of(account));
     }
 
@@ -94,9 +94,9 @@ public sealed class CreateAccount : IEndpoint
     /// the ownership work; see docs/model-rename-pass.md.
     /// </para>
     /// </summary>
-    private static async Task<string> NextAccountNumber(XpenseDbContext db, CancellationToken ct)
+    private static async Task<string> NextAccountNumber(XpenseDbContext dbContext, CancellationToken cancellationToken)
     {
-        var numbers = await db.Accounts.Select(a => a.AccountNumber).ToListAsync(ct);
+        var numbers = await dbContext.Accounts.Select(account => account.AccountNumber).ToListAsync(cancellationToken);
 
         return numbers.Count == 0
             ? FirstAccountNumber.ToString()

--- a/src/Xpense/Xpense.API/Features/Accounts/DeleteAccount.cs
+++ b/src/Xpense/Xpense.API/Features/Accounts/DeleteAccount.cs
@@ -16,15 +16,15 @@ public sealed class DeleteAccount : IEndpoint
     public static void Map(IEndpointRouteBuilder app) =>
         app.MapDelete("/api/v1/accounts/{accountNumber}", Handle).WithName(nameof(DeleteAccount));
 
-    private static async Task<NoContent> Handle(string accountNumber, XpenseDbContext db, CancellationToken ct)
+    private static async Task<NoContent> Handle(string accountNumber, XpenseDbContext dbContext, CancellationToken cancellationToken)
     {
-        var account = await db.Accounts.FirstOrDefaultAsync(a => a.AccountNumber == accountNumber, ct)
+        var account = await dbContext.Accounts.FirstOrDefaultAsync(account => account.AccountNumber == accountNumber, cancellationToken)
                       ?? throw new AccountNotFoundException(accountNumber);
 
         account.MarkAsDeleted();
         account.Touch();
 
-        if (await db.SaveChangesAsync(ct) < 1)
+        if (await dbContext.SaveChangesAsync(cancellationToken) < 1)
             throw new AccountDeletionFailedException(account.Id);
 
         return TypedResults.NoContent();

--- a/src/Xpense/Xpense.API/Features/Accounts/GetAccountByNumber.cs
+++ b/src/Xpense/Xpense.API/Features/Accounts/GetAccountByNumber.cs
@@ -18,12 +18,12 @@ public sealed class GetAccountByNumber : IEndpoint
 
     private static async Task<Ok<AccountResponse>> Handle(
         string accountNumber,
-        XpenseDbContext db,
-        CancellationToken ct)
+        XpenseDbContext dbContext,
+        CancellationToken cancellationToken)
     {
-        var account = await db.Accounts
+        var account = await dbContext.Accounts
             .AsNoTracking()
-            .FirstOrDefaultAsync(a => a.AccountNumber == accountNumber, ct)
+            .FirstOrDefaultAsync(account => account.AccountNumber == accountNumber, cancellationToken)
             ?? throw new AccountNotFoundException(accountNumber);
 
         return TypedResults.Ok(AccountResponse.Of(account));

--- a/src/Xpense/Xpense.API/Features/Accounts/ListAccounts.cs
+++ b/src/Xpense/Xpense.API/Features/Accounts/ListAccounts.cs
@@ -16,9 +16,9 @@ public sealed class ListAccounts : IEndpoint
     public static void Map(IEndpointRouteBuilder app) =>
         app.MapGet("/api/v1/accounts", Handle).WithName(nameof(ListAccounts));
 
-    private static async Task<Ok<AccountResponse[]>> Handle(XpenseDbContext db, CancellationToken ct)
+    private static async Task<Ok<AccountResponse[]>> Handle(XpenseDbContext dbContext, CancellationToken cancellationToken)
     {
-        var accounts = await db.Accounts.AsNoTracking().ToListAsync(ct);
+        var accounts = await dbContext.Accounts.AsNoTracking().ToListAsync(cancellationToken);
         return TypedResults.Ok(accounts.Select(AccountResponse.Of).ToArray());
     }
 }

--- a/src/Xpense/Xpense.API/Features/Accounts/UpdateAccount.cs
+++ b/src/Xpense/Xpense.API/Features/Accounts/UpdateAccount.cs
@@ -32,17 +32,17 @@ public sealed class UpdateAccount : IEndpoint
     private static async Task<Ok<AccountResponse>> Handle(
         string accountNumber,
         Request request,
-        XpenseDbContext db,
-        CancellationToken ct)
+        XpenseDbContext dbContext,
+        CancellationToken cancellationToken)
     {
-        var account = await db.Accounts.FirstOrDefaultAsync(a => a.AccountNumber == accountNumber, ct)
+        var account = await dbContext.Accounts.FirstOrDefaultAsync(account => account.AccountNumber == accountNumber, cancellationToken)
                       ?? throw new AccountNotFoundException(accountNumber);
 
         account.Label = request.Label;
         account.IsDefault = request.IsDefault;
         account.Touch();
 
-        if (await db.SaveChangesAsync(ct) < 1)
+        if (await dbContext.SaveChangesAsync(cancellationToken) < 1)
             throw new AccountUpdateFailedException(account.Id);
 
         return TypedResults.Ok(AccountResponse.Of(account));

--- a/src/Xpense/Xpense.API/Features/Analytics/GetSpendingByCategory.cs
+++ b/src/Xpense/Xpense.API/Features/Analytics/GetSpendingByCategory.cs
@@ -21,8 +21,8 @@ public sealed class GetSpendingByCategory : IEndpoint
             .WithName(nameof(GetSpendingByCategory));
 
     private static async Task<Ok<SpendingByCategoryResponse>> Handle(
-        XpenseDbContext db,
-        CancellationToken ct)
+        XpenseDbContext dbContext,
+        CancellationToken cancellationToken)
     {
         // Timestamps are stored UTC, so "today" is a UTC day.
         var today = DateTime.UtcNow.Date;
@@ -30,14 +30,14 @@ public sealed class GetSpendingByCategory : IEndpoint
         // Expenses only, and the filter has to be expressed as columns because Kind is computed.
         // Transfers would have no category to group by, and income is not spending -- it used to be
         // counted here, because nothing filtered by direction at all.
-        var expensesToday = await db.Transactions
+        var expensesToday = await dbContext.Transactions
             .AsNoTracking()
             .Include(transaction => transaction.Category)
             .ThenInclude(category => category.Priority)
             .Where(transaction => transaction.SourceAccountId != null
                                   && transaction.DestinationAccountId == null
                                   && transaction.OccurredAt.Date == today)
-            .ToListAsync(ct);
+            .ToListAsync(cancellationToken);
 
         // Grouped by currency as well as by category, because nothing converts. This used to label
         // the whole total with expensesToday[0].Currency and sum minor units across every currency

--- a/src/Xpense/Xpense.API/Features/Budgets/CreateBudget.cs
+++ b/src/Xpense/Xpense.API/Features/Budgets/CreateBudget.cs
@@ -78,13 +78,13 @@ public sealed class CreateBudget : IEndpoint
 
     private static async Task<Created<BudgetResponse>> Handle(
         Request request,
-        XpenseDbContext db,
-        HttpContext http,
-        CancellationToken ct)
+        XpenseDbContext dbContext,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
     {
-        var category = await db.Categories
+        var category = await dbContext.Categories
             .Include(item => item.Priority)
-            .FirstOrDefaultAsync(item => item.Id == request.CategoryId, ct)
+            .FirstOrDefaultAsync(item => item.Id == request.CategoryId, cancellationToken)
             ?? throw new CategoryNotFoundException(request.CategoryId);
 
         CurrencyParser.TryParse(request.Amount.Currency, out var currency);
@@ -97,15 +97,15 @@ public sealed class CreateBudget : IEndpoint
             request.StartsOn.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc),
             request.EndsOn?.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc));
 
-        db.Budgets.Add(budget);
+        dbContext.Budgets.Add(budget);
 
-        if (await db.SaveChangesAsync(ct) < 1)
+        if (await dbContext.SaveChangesAsync(cancellationToken) < 1)
             throw new BudgetCreationFailedException(request.CategoryId);
 
         // A freshly stated budget has measured nothing worth reporting yet, and the caller asked to
         // create rather than to read, so no period is computed here.
         return TypedResults.Created(
-            http.ResourceUri($"/api/v1/budgets/{budget.Id}"),
+            httpContext.ResourceUri($"/api/v1/budgets/{budget.Id}"),
             BudgetResponse.Of(budget, null));
     }
 }

--- a/src/Xpense/Xpense.API/Features/Budgets/DeleteBudget.cs
+++ b/src/Xpense/Xpense.API/Features/Budgets/DeleteBudget.cs
@@ -16,15 +16,15 @@ public sealed class DeleteBudget : IEndpoint
     public static void Map(IEndpointRouteBuilder app) =>
         app.MapDelete("/api/v1/budgets/{id:int}", Handle).WithName(nameof(DeleteBudget));
 
-    private static async Task<NoContent> Handle(int id, XpenseDbContext db, CancellationToken ct)
+    private static async Task<NoContent> Handle(int id, XpenseDbContext dbContext, CancellationToken cancellationToken)
     {
-        var budget = await db.Budgets.FirstOrDefaultAsync(item => item.Id == id, ct)
+        var budget = await dbContext.Budgets.FirstOrDefaultAsync(item => item.Id == id, cancellationToken)
                      ?? throw new BudgetNotFoundException(id);
 
         budget.MarkAsDeleted();
         budget.Touch();
 
-        if (await db.SaveChangesAsync(ct) < 1)
+        if (await dbContext.SaveChangesAsync(cancellationToken) < 1)
             throw new BudgetDeletionFailedException(id);
 
         return TypedResults.NoContent();

--- a/src/Xpense/Xpense.API/Features/Budgets/GetBudgetById.cs
+++ b/src/Xpense/Xpense.API/Features/Budgets/GetBudgetById.cs
@@ -29,17 +29,17 @@ public sealed class GetBudgetById : IEndpoint
 
     private static async Task<Ok<BudgetResponse>> Handle(
         int id,
-        XpenseDbContext db,
-        CancellationToken ct,
+        XpenseDbContext dbContext,
+        CancellationToken cancellationToken,
         DateTimeOffset? on = null)
     {
         var instant = on?.UtcDateTime ?? DateTime.UtcNow;
 
-        var budget = await db.Budgets
+        var budget = await dbContext.Budgets
             .AsNoTracking()
             .Include(item => item.Category)
             .ThenInclude(category => category!.Priority)
-            .FirstOrDefaultAsync(item => item.Id == id, ct)
+            .FirstOrDefaultAsync(item => item.Id == id, cancellationToken)
             ?? throw new BudgetNotFoundException(id);
 
         var period = budget.PeriodOn(instant);
@@ -47,7 +47,7 @@ public sealed class GetBudgetById : IEndpoint
         if (period is null)
             return TypedResults.Ok(BudgetResponse.Of(budget, null));
 
-        var totals = await db.Transactions
+        var totals = await dbContext.Transactions
             .AsNoTracking()
             .Where(transaction => transaction.SourceAccountId != null
                                   && transaction.DestinationAccountId == null
@@ -60,7 +60,7 @@ public sealed class GetBudgetById : IEndpoint
                 Currency = group.Key,
                 MinorUnits = group.Sum(transaction => transaction.AmountMinorUnits)
             })
-            .ToListAsync(ct);
+            .ToListAsync(cancellationToken);
 
         // Built in the budget's own currency: Money.Zero is EUR, and a EUR zero taken from a USD
         // limit throws instead of returning the limit untouched.

--- a/src/Xpense/Xpense.API/Features/Budgets/ListBudgets.cs
+++ b/src/Xpense/Xpense.API/Features/Budgets/ListBudgets.cs
@@ -30,20 +30,20 @@ public sealed class ListBudgets : IEndpoint
         app.MapGet("/api/v1/budgets", Handle).WithName(nameof(ListBudgets));
 
     private static async Task<Ok<BudgetResponse[]>> Handle(
-        XpenseDbContext db,
-        CancellationToken ct,
+        XpenseDbContext dbContext,
+        CancellationToken cancellationToken,
         DateTimeOffset? on = null)
     {
         // Which period a budget is in depends on a moment. Default to now; `?on=` asks about another.
         var instant = on?.UtcDateTime ?? DateTime.UtcNow;
 
-        var budgets = await db.Budgets
+        var budgets = await dbContext.Budgets
             .AsNoTracking()
             .Include(budget => budget.Category)
             .ThenInclude(category => category!.Priority)
             .OrderBy(budget => budget.CategoryId)
             .ThenBy(budget => budget.Id)
-            .ToListAsync(ct);
+            .ToListAsync(cancellationToken);
 
         var measured = budgets
             .Select(budget => (Budget: budget, Period: budget.PeriodOn(instant)))
@@ -60,7 +60,7 @@ public sealed class ListBudgets : IEndpoint
 
         // Expenses only, and the filter is written as columns because Kind is computed. A transfer
         // has no category to count against, and income is not spending.
-        var expenses = await db.Transactions
+        var expenses = await dbContext.Transactions
             .AsNoTracking()
             .Where(transaction => transaction.SourceAccountId != null
                                   && transaction.DestinationAccountId == null
@@ -73,7 +73,7 @@ public sealed class ListBudgets : IEndpoint
                 transaction.Currency,
                 transaction.OccurredAt,
                 transaction.AmountMinorUnits))
-            .ToListAsync(ct);
+            .ToListAsync(cancellationToken);
 
         var responses = measured
             .Select(entry => entry.Period is null

--- a/src/Xpense/Xpense.API/Features/Budgets/UpdateBudget.cs
+++ b/src/Xpense/Xpense.API/Features/Budgets/UpdateBudget.cs
@@ -70,13 +70,13 @@ public sealed class UpdateBudget : IEndpoint
     private static async Task<Ok<BudgetResponse>> Handle(
         int id,
         Request request,
-        XpenseDbContext db,
-        CancellationToken ct)
+        XpenseDbContext dbContext,
+        CancellationToken cancellationToken)
     {
-        var budget = await db.Budgets
+        var budget = await dbContext.Budgets
             .Include(item => item.Category)
             .ThenInclude(category => category!.Priority)
-            .FirstOrDefaultAsync(item => item.Id == id, ct)
+            .FirstOrDefaultAsync(item => item.Id == id, cancellationToken)
             ?? throw new BudgetNotFoundException(id);
 
         CurrencyParser.TryParse(request.Amount.Currency, out var currency);
@@ -88,7 +88,7 @@ public sealed class UpdateBudget : IEndpoint
             request.StartsOn.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc),
             request.EndsOn?.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc));
 
-        if (await db.SaveChangesAsync(ct) < 1)
+        if (await dbContext.SaveChangesAsync(cancellationToken) < 1)
             throw new BudgetUpdateFailedException(id);
 
         return TypedResults.Ok(BudgetResponse.Of(budget, null));

--- a/src/Xpense/Xpense.API/Features/Categories/CreateCategory.cs
+++ b/src/Xpense/Xpense.API/Features/Categories/CreateCategory.cs
@@ -37,11 +37,11 @@ public sealed class CreateCategory : IEndpoint
 
     private static async Task<Created<CategoryResponse>> Handle(
         Request request,
-        XpenseDbContext db,
-        HttpContext http,
-        CancellationToken ct)
+        XpenseDbContext dbContext,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
     {
-        var priority = await db.Priorities.FirstOrDefaultAsync(p => p.Id == request.PriorityId, ct)
+        var priority = await dbContext.Priorities.FirstOrDefaultAsync(priority => priority.Id == request.PriorityId, cancellationToken)
                        ?? throw new PriorityNotFoundException(request.PriorityId);
 
         var category = new Category
@@ -51,13 +51,13 @@ public sealed class CreateCategory : IEndpoint
             CreatedAt = DateTime.UtcNow
         };
 
-        db.Categories.Add(category);
+        dbContext.Categories.Add(category);
 
-        if (await db.SaveChangesAsync(ct) < 1)
+        if (await dbContext.SaveChangesAsync(cancellationToken) < 1)
             throw new CategoryCreationFailedException(request.Label);
 
         return TypedResults.Created(
-            http.ResourceUri($"/api/v1/categories/{category.Id}"),
+            httpContext.ResourceUri($"/api/v1/categories/{category.Id}"),
             CategoryResponse.Of(category));
     }
 }

--- a/src/Xpense/Xpense.API/Features/Categories/DeleteCategory.cs
+++ b/src/Xpense/Xpense.API/Features/Categories/DeleteCategory.cs
@@ -17,11 +17,11 @@ public sealed class DeleteCategory : IEndpoint
     public static void Map(IEndpointRouteBuilder app) =>
         app.MapDelete("/api/v1/categories/{id:int}", Handle).WithName(nameof(DeleteCategory));
 
-    private static async Task<NoContent> Handle(int id, XpenseDbContext db, CancellationToken ct)
+    private static async Task<NoContent> Handle(int id, XpenseDbContext dbContext, CancellationToken cancellationToken)
     {
         // CategoryRepository.DeleteById wrapped a FirstAsync in catch-all and rethrew as
         // CategoryNotFoundException. Same outcome, without swallowing unrelated failures.
-        var category = await db.Categories.FirstOrDefaultAsync(item => item.Id == id, ct)
+        var category = await dbContext.Categories.FirstOrDefaultAsync(item => item.Id == id, cancellationToken)
                        ?? throw new CategoryNotFoundException(id);
 
         category.MarkAsDeleted();
@@ -32,7 +32,7 @@ public sealed class DeleteCategory : IEndpoint
         // filter hides the row, and an Include would hand back null for a category that is still
         // referenced. Budget is an entity rather than another slice's type, so reaching it from here
         // does not cross a slice boundary.
-        var budgets = await db.Budgets.Where(budget => budget.CategoryId == id).ToListAsync(ct);
+        var budgets = await dbContext.Budgets.Where(budget => budget.CategoryId == id).ToListAsync(cancellationToken);
 
         foreach (var budget in budgets)
         {
@@ -40,7 +40,7 @@ public sealed class DeleteCategory : IEndpoint
             budget.Touch();
         }
 
-        if (await db.SaveChangesAsync(ct) < 1)
+        if (await dbContext.SaveChangesAsync(cancellationToken) < 1)
             throw new CategoryDeletionFailedException(id);
 
         return TypedResults.NoContent();

--- a/src/Xpense/Xpense.API/Features/Categories/GetCategoryById.cs
+++ b/src/Xpense/Xpense.API/Features/Categories/GetCategoryById.cs
@@ -17,12 +17,12 @@ public sealed class GetCategoryById : IEndpoint
     public static void Map(IEndpointRouteBuilder app) =>
         app.MapGet("/api/v1/categories/{id:int}", Handle).WithName(nameof(GetCategoryById));
 
-    private static async Task<Ok<CategoryResponse>> Handle(int id, XpenseDbContext db, CancellationToken ct)
+    private static async Task<Ok<CategoryResponse>> Handle(int id, XpenseDbContext dbContext, CancellationToken cancellationToken)
     {
-        var category = await db.Categories
+        var category = await dbContext.Categories
             .AsNoTracking()
             .Include(item => item.Priority)
-            .FirstOrDefaultAsync(item => item.Id == id, ct)
+            .FirstOrDefaultAsync(item => item.Id == id, cancellationToken)
             ?? throw new CategoryNotFoundException(id);
 
         return TypedResults.Ok(CategoryResponse.Of(category));

--- a/src/Xpense/Xpense.API/Features/Categories/ListCategories.cs
+++ b/src/Xpense/Xpense.API/Features/Categories/ListCategories.cs
@@ -17,12 +17,12 @@ public sealed class ListCategories : IEndpoint
     public static void Map(IEndpointRouteBuilder app) =>
         app.MapGet("/api/v1/categories", Handle).WithName(nameof(ListCategories));
 
-    private static async Task<Ok<CategoryResponse[]>> Handle(XpenseDbContext db, CancellationToken ct)
+    private static async Task<Ok<CategoryResponse[]>> Handle(XpenseDbContext dbContext, CancellationToken cancellationToken)
     {
-        var categories = await db.Categories
+        var categories = await dbContext.Categories
             .AsNoTracking()
             .Include(category => category.Priority)
-            .ToListAsync(ct);
+            .ToListAsync(cancellationToken);
 
         return TypedResults.Ok(categories.Select(CategoryResponse.Of).ToArray());
     }

--- a/src/Xpense/Xpense.API/Features/Categories/UpdateCategory.cs
+++ b/src/Xpense/Xpense.API/Features/Categories/UpdateCategory.cs
@@ -36,20 +36,20 @@ public sealed class UpdateCategory : IEndpoint
     private static async Task<Ok<CategoryResponse>> Handle(
         int id,
         Request request,
-        XpenseDbContext db,
-        CancellationToken ct)
+        XpenseDbContext dbContext,
+        CancellationToken cancellationToken)
     {
-        var priority = await db.Priorities.FirstOrDefaultAsync(p => p.Id == request.PriorityId, ct)
+        var priority = await dbContext.Priorities.FirstOrDefaultAsync(priority => priority.Id == request.PriorityId, cancellationToken)
                        ?? throw new PriorityNotFoundException(request.PriorityId);
 
-        var category = await db.Categories.FirstOrDefaultAsync(item => item.Id == id, ct)
+        var category = await dbContext.Categories.FirstOrDefaultAsync(item => item.Id == id, cancellationToken)
                        ?? throw new CategoryNotFoundException(id);
 
         category.Label = request.Label;
         category.Priority = priority;
         category.Touch();
 
-        if (await db.SaveChangesAsync(ct) < 1)
+        if (await dbContext.SaveChangesAsync(cancellationToken) < 1)
             throw new CategoryUpdateFailedException(id);
 
         return TypedResults.Ok(CategoryResponse.Of(category));

--- a/src/Xpense/Xpense.API/Features/Merchants/ListMerchants.cs
+++ b/src/Xpense/Xpense.API/Features/Merchants/ListMerchants.cs
@@ -18,9 +18,9 @@ public sealed class ListMerchants : IEndpoint
     public static void Map(IEndpointRouteBuilder app) =>
         app.MapGet("/api/v1/merchants", Handle).WithName(nameof(ListMerchants));
 
-    private static async Task<Ok<MerchantResponse[]>> Handle(XpenseDbContext db, CancellationToken ct)
+    private static async Task<Ok<MerchantResponse[]>> Handle(XpenseDbContext dbContext, CancellationToken cancellationToken)
     {
-        var merchants = await db.Merchants.AsNoTracking().ToListAsync(ct);
+        var merchants = await dbContext.Merchants.AsNoTracking().ToListAsync(cancellationToken);
         return TypedResults.Ok(merchants.Select(MerchantResponse.Of).ToArray());
     }
 }

--- a/src/Xpense/Xpense.API/Features/Priorities/ListPriorities.cs
+++ b/src/Xpense/Xpense.API/Features/Priorities/ListPriorities.cs
@@ -25,14 +25,14 @@ public sealed class ListPriorities : IEndpoint
     public static void Map(IEndpointRouteBuilder app) =>
         app.MapGet("/api/v1/priorities", Handle).WithName(nameof(ListPriorities));
 
-    private static async Task<Ok<PriorityResponse[]>> Handle(XpenseDbContext db, CancellationToken ct)
+    private static async Task<Ok<PriorityResponse[]>> Handle(XpenseDbContext dbContext, CancellationToken cancellationToken)
     {
         // By id, which is seed order: Extreme, High, Medium, Low, None. Weight would put None first,
         // because None weighs 0 and Extreme weighs 1.
-        var priorities = await db.Priorities
+        var priorities = await dbContext.Priorities
             .AsNoTracking()
             .OrderBy(priority => priority.Id)
-            .ToListAsync(ct);
+            .ToListAsync(cancellationToken);
 
         return TypedResults.Ok(priorities.Select(PriorityResponse.Of).ToArray());
     }

--- a/src/Xpense/Xpense.API/Features/Tags/CreateTag.cs
+++ b/src/Xpense/Xpense.API/Features/Tags/CreateTag.cs
@@ -35,9 +35,9 @@ public sealed class CreateTag : IEndpoint
 
     private static async Task<Created<TagResponse>> Handle(
         Request request,
-        XpenseDbContext db,
-        HttpContext http,
-        CancellationToken ct)
+        XpenseDbContext dbContext,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
     {
         var tag = new Tag
         {
@@ -47,11 +47,11 @@ public sealed class CreateTag : IEndpoint
             CreatedAt = DateTime.UtcNow
         };
 
-        db.Tags.Add(tag);
+        dbContext.Tags.Add(tag);
 
-        if (await db.SaveChangesAsync(ct) < 1)
+        if (await dbContext.SaveChangesAsync(cancellationToken) < 1)
             throw new TagCreationFailedException(tag.Label);
 
-        return TypedResults.Created(http.ResourceUri($"/api/v1/tags/{tag.Id}"), TagResponse.Of(tag));
+        return TypedResults.Created(httpContext.ResourceUri($"/api/v1/tags/{tag.Id}"), TagResponse.Of(tag));
     }
 }

--- a/src/Xpense/Xpense.API/Features/Tags/DeleteTag.cs
+++ b/src/Xpense/Xpense.API/Features/Tags/DeleteTag.cs
@@ -16,9 +16,9 @@ public sealed class DeleteTag : IEndpoint
     public static void Map(IEndpointRouteBuilder app) =>
         app.MapDelete("/api/v1/tags/{id:int}", Handle).WithName(nameof(DeleteTag));
 
-    private static async Task<NoContent> Handle(int id, XpenseDbContext db, CancellationToken ct)
+    private static async Task<NoContent> Handle(int id, XpenseDbContext dbContext, CancellationToken cancellationToken)
     {
-        var tag = await db.Tags.FirstOrDefaultAsync(t => t.Id == id, ct)
+        var tag = await dbContext.Tags.FirstOrDefaultAsync(tag => tag.Id == id, cancellationToken)
                   ?? throw new TagNotFoundException(id);
 
         // Soft delete: the global query filter hides IsDeleted rows. Preserved from the
@@ -26,7 +26,7 @@ public sealed class DeleteTag : IEndpoint
         tag.MarkAsDeleted();
         tag.Touch();
 
-        if (await db.SaveChangesAsync(ct) < 1)
+        if (await dbContext.SaveChangesAsync(cancellationToken) < 1)
             throw new TagDeletionFailedException(id);
 
         return TypedResults.NoContent();

--- a/src/Xpense/Xpense.API/Features/Tags/GetTagById.cs
+++ b/src/Xpense/Xpense.API/Features/Tags/GetTagById.cs
@@ -16,9 +16,9 @@ public sealed class GetTagById : IEndpoint
     public static void Map(IEndpointRouteBuilder app) =>
         app.MapGet("/api/v1/tags/{id:int}", Handle).WithName(nameof(GetTagById));
 
-    private static async Task<Ok<TagResponse>> Handle(int id, XpenseDbContext db, CancellationToken ct)
+    private static async Task<Ok<TagResponse>> Handle(int id, XpenseDbContext dbContext, CancellationToken cancellationToken)
     {
-        var tag = await db.Tags.AsNoTracking().FirstOrDefaultAsync(t => t.Id == id, ct)
+        var tag = await dbContext.Tags.AsNoTracking().FirstOrDefaultAsync(tag => tag.Id == id, cancellationToken)
                   ?? throw new TagNotFoundException(id);
 
         return TypedResults.Ok(TagResponse.Of(tag));

--- a/src/Xpense/Xpense.API/Features/Tags/ListTags.cs
+++ b/src/Xpense/Xpense.API/Features/Tags/ListTags.cs
@@ -16,9 +16,9 @@ public sealed class ListTags : IEndpoint
     public static void Map(IEndpointRouteBuilder app) =>
         app.MapGet("/api/v1/tags", Handle).WithName(nameof(ListTags));
 
-    private static async Task<Ok<TagResponse[]>> Handle(XpenseDbContext db, CancellationToken ct)
+    private static async Task<Ok<TagResponse[]>> Handle(XpenseDbContext dbContext, CancellationToken cancellationToken)
     {
-        var tags = await db.Tags.AsNoTracking().ToListAsync(ct);
+        var tags = await dbContext.Tags.AsNoTracking().ToListAsync(cancellationToken);
         return TypedResults.Ok(tags.Select(TagResponse.Of).ToArray());
     }
 }

--- a/src/Xpense/Xpense.API/Features/Tags/UpdateTag.cs
+++ b/src/Xpense/Xpense.API/Features/Tags/UpdateTag.cs
@@ -35,12 +35,12 @@ public sealed class UpdateTag : IEndpoint
     private static async Task<Ok<TagResponse>> Handle(
         int id,
         Request request,
-        XpenseDbContext db,
-        CancellationToken ct)
+        XpenseDbContext dbContext,
+        CancellationToken cancellationToken)
     {
         // The old UpdateTagUseCase dereferenced the entity without a null check and threw
         // NullReferenceException for a missing id.
-        var tag = await db.Tags.FirstOrDefaultAsync(t => t.Id == id, ct)
+        var tag = await dbContext.Tags.FirstOrDefaultAsync(tag => tag.Id == id, cancellationToken)
                   ?? throw new TagNotFoundException(id);
 
         tag.Label = request.Label;
@@ -48,7 +48,7 @@ public sealed class UpdateTag : IEndpoint
         tag.FgColorHex = TagColour.Normalise(request.FgColorHex);
         tag.Touch();
 
-        if (await db.SaveChangesAsync(ct) < 1)
+        if (await dbContext.SaveChangesAsync(cancellationToken) < 1)
             throw new TagUpdateFailedException(id);
 
         return TypedResults.Ok(TagResponse.Of(tag));

--- a/src/Xpense/Xpense.API/Features/Transactions/CreateTransaction.cs
+++ b/src/Xpense/Xpense.API/Features/Transactions/CreateTransaction.cs
@@ -112,11 +112,11 @@ public sealed class CreateTransaction : IEndpoint
 
     private static async Task<Created<TransactionResponse>> Handle(
         Request request,
-        XpenseDbContext db,
+        XpenseDbContext dbContext,
         OptionResolver<Merchant> merchants,
         OptionResolver<Tag> tags,
-        HttpContext http,
-        CancellationToken ct)
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
     {
         // The validator already rejected anything else.
         CurrencyParser.TryParse(request.Amount.Currency, out var currency);
@@ -127,7 +127,7 @@ public sealed class CreateTransaction : IEndpoint
         // Serializable because every kind reads a balance and writes it back. The old transfer
         // endpoint isolated this and the old income/expense endpoint did not; one path means one
         // answer, and the safer one is the correct one.
-        await using var scope = await db.Database.BeginTransactionAsync(IsolationLevel.Serializable, ct);
+        await using var scope = await dbContext.Database.BeginTransactionAsync(IsolationLevel.Serializable, cancellationToken);
 
         try
         {
@@ -135,34 +135,34 @@ public sealed class CreateTransaction : IEndpoint
             // reads made within the transaction, so a balance read outside it leaves the
             // insufficient-funds guard unprotected: two concurrent transfers from one account would
             // both see the old balance, both pass the check, and both commit.
-            var source = await FindAccount(db, request.SourceAccountNumber, ct);
-            var destination = await FindAccount(db, request.DestinationAccountNumber, ct);
-            var resolvedTags = await ResolveTags(tags, request.Tags, ct);
+            var source = await FindAccount(dbContext, request.SourceAccountNumber, cancellationToken);
+            var destination = await FindAccount(dbContext, request.DestinationAccountNumber, cancellationToken);
+            var resolvedTags = await ResolveTags(tags, request.Tags, cancellationToken);
 
             var transaction = source is not null && destination is not null
                 ? Domain.Entities.Transaction.Transfer(source, destination, amount, request.Reason, resolvedTags, occurredAt)
-                : await OneSided(db, merchants, request, source, destination, amount, resolvedTags, occurredAt, ct);
+                : await OneSided(dbContext, merchants, request, source, destination, amount, resolvedTags, occurredAt, cancellationToken);
 
-            db.Transactions.Add(transaction);
+            dbContext.Transactions.Add(transaction);
 
-            if (await db.SaveChangesAsync(ct) < 1)
+            if (await dbContext.SaveChangesAsync(cancellationToken) < 1)
                 throw Failure(request, amount, transaction.Kind);
 
-            await scope.CommitAsync(ct);
+            await scope.CommitAsync(cancellationToken);
 
             return TypedResults.Created(
-                http.ResourceUri($"/api/v1/transactions/{transaction.Id}"),
+                httpContext.ResourceUri($"/api/v1/transactions/{transaction.Id}"),
                 TransactionResponse.Of(transaction));
         }
         catch
         {
-            await scope.RollbackAsync(ct);
+            await scope.RollbackAsync(cancellationToken);
             throw;
         }
     }
 
     private static async Task<Transaction> OneSided(
-        XpenseDbContext db,
+        XpenseDbContext dbContext,
         OptionResolver<Merchant> merchants,
         Request request,
         Account? source,
@@ -170,14 +170,14 @@ public sealed class CreateTransaction : IEndpoint
         Money amount,
         List<Tag>? tags,
         DateTime occurredAt,
-        CancellationToken ct)
+        CancellationToken cancellationToken)
     {
-        var category = await db.Categories
+        var category = await dbContext.Categories
             .Include(item => item.Priority)
-            .FirstOrDefaultAsync(item => item.Id == request.CategoryId, ct)
+            .FirstOrDefaultAsync(item => item.Id == request.CategoryId, cancellationToken)
             ?? throw new CategoryNotFoundException(request.CategoryId!.Value);
 
-        var merchant = await merchants.Resolve(ToMerchantOption(request.Merchant!), ct)
+        var merchant = await merchants.Resolve(ToMerchantOption(request.Merchant!), cancellationToken)
                        ?? throw new MerchantNotFoundException(request.Merchant!.Label);
 
         // Deposit and Withdraw reject an amount whose currency differs from the account's, so a USD
@@ -197,19 +197,19 @@ public sealed class CreateTransaction : IEndpoint
             ? new WithdrawCreationFailedException(amount.ToDecimal(), request.SourceAccountNumber!)
             : new DepositCreationFailedException(amount.ToDecimal(), request.DestinationAccountNumber!);
 
-    private static async Task<Account?> FindAccount(XpenseDbContext db, string? accountNumber, CancellationToken ct)
+    private static async Task<Account?> FindAccount(XpenseDbContext dbContext, string? accountNumber, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(accountNumber))
             return null;
 
-        return await db.Accounts.FirstOrDefaultAsync(account => account.AccountNumber == accountNumber, ct)
+        return await dbContext.Accounts.FirstOrDefaultAsync(account => account.AccountNumber == accountNumber, cancellationToken)
                ?? throw new AccountNotFoundException(accountNumber);
     }
 
     private static async Task<List<Tag>?> ResolveTags(
         OptionResolver<Tag> resolver,
         IReadOnlyList<OptionRequest>? requested,
-        CancellationToken ct)
+        CancellationToken cancellationToken)
     {
         if (requested is null)
             return null;
@@ -217,7 +217,7 @@ public sealed class CreateTransaction : IEndpoint
         List<Tag> resolved = [];
         foreach (var option in requested)
         {
-            if (await resolver.Resolve(ToTagOption(option), ct) is { } tag)
+            if (await resolver.Resolve(ToTagOption(option), cancellationToken) is { } tag)
                 resolved.Add(tag);
         }
 

--- a/src/Xpense/Xpense.API/Features/Transactions/GetTransactionById.cs
+++ b/src/Xpense/Xpense.API/Features/Transactions/GetTransactionById.cs
@@ -16,11 +16,11 @@ public sealed class GetTransactionById : IEndpoint
     public static void Map(IEndpointRouteBuilder app) =>
         app.MapGet("/api/v1/transactions/{id:int}", Handle).WithName(nameof(GetTransactionById));
 
-    private static async Task<Ok<TransactionResponse>> Handle(int id, XpenseDbContext db, CancellationToken ct)
+    private static async Task<Ok<TransactionResponse>> Handle(int id, XpenseDbContext dbContext, CancellationToken cancellationToken)
     {
-        var transaction = await db.WithDetails()
+        var transaction = await dbContext.WithDetails()
             .AsNoTracking()
-            .SingleOrDefaultAsync(item => item.Id == id, ct)
+            .SingleOrDefaultAsync(item => item.Id == id, cancellationToken)
             ?? throw new TransactionNotFoundException(id);
 
         return TypedResults.Ok(TransactionResponse.Of(transaction));

--- a/src/Xpense/Xpense.API/Features/Transactions/ListTransactions.cs
+++ b/src/Xpense/Xpense.API/Features/Transactions/ListTransactions.cs
@@ -21,17 +21,17 @@ public sealed class ListTransactions : IEndpoint
         app.MapGet("/api/v1/transactions", Handle).WithName(nameof(ListTransactions));
 
     private static async Task<Ok<TransactionPageResponse>> Handle(
-        XpenseDbContext db,
-        CancellationToken ct,
+        XpenseDbContext dbContext,
+        CancellationToken cancellationToken,
         int page = DefaultPage,
         int pageSize = DefaultPageSize)
     {
         if (page <= 0 || pageSize <= 0)
             throw new InvalidFilteredResultParams(page, pageSize);
 
-        var query = db.WithDetails().AsNoTracking();
+        var query = dbContext.WithDetails().AsNoTracking();
 
-        var totalItems = await query.CountAsync(ct);
+        var totalItems = await query.CountAsync(cancellationToken);
         var totalPages = totalItems / pageSize + (totalItems % pageSize > 0 ? 1 : 0);
 
         var transactions = await query
@@ -40,7 +40,7 @@ public sealed class ListTransactions : IEndpoint
             .OrderByDescending(transaction => transaction.OccurredAt)
             .Skip(pageSize * (page - 1))
             .Take(pageSize)
-            .ToListAsync(ct);
+            .ToListAsync(cancellationToken);
 
         return TypedResults.Ok(new TransactionPageResponse(
             transactions.Select(TransactionResponse.Of).ToArray(),

--- a/src/Xpense/Xpense.API/Features/Transactions/TransactionQueries.cs
+++ b/src/Xpense/Xpense.API/Features/Transactions/TransactionQueries.cs
@@ -15,8 +15,8 @@ internal static class TransactionQueries
     /// side may be absent -- a null side means the money crossed the system boundary.
     /// </para>
     /// </summary>
-    public static IQueryable<Transaction> WithDetails(this XpenseDbContext db) =>
-        db.Transactions
+    public static IQueryable<Transaction> WithDetails(this XpenseDbContext dbContext) =>
+        dbContext.Transactions
             .Include(transaction => transaction.Category)
             .ThenInclude(category => category.Priority)
             .Include(transaction => transaction.Merchant)

--- a/src/Xpense/Xpense.API/Infrastructure/HttpContextExtensions.cs
+++ b/src/Xpense/Xpense.API/Infrastructure/HttpContextExtensions.cs
@@ -14,6 +14,6 @@ public static class HttpContextExtensions
     /// every create slice goes through here rather than each one deciding.
     /// </para>
     /// </summary>
-    public static string ResourceUri(this HttpContext http, string path) =>
-        UriHelper.BuildAbsolute(http.Request.Scheme, http.Request.Host, path: path);
+    public static string ResourceUri(this HttpContext httpContext, string path) =>
+        UriHelper.BuildAbsolute(httpContext.Request.Scheme, httpContext.Request.Host, path: path);
 }

--- a/src/Xpense/Xpense.Persistence/OptionResolver.cs
+++ b/src/Xpense/Xpense.Persistence/OptionResolver.cs
@@ -13,50 +13,50 @@ namespace Xpense.Persistence;
 /// duplicates merchants. It used to be OptionRepository&lt;T&gt;.GetOrCreateIfMissing.
 /// </para>
 /// </summary>
-public sealed class OptionResolver<TEntity>(XpenseDbContext db)
+public sealed class OptionResolver<TEntity>(XpenseDbContext dbContext)
     where TEntity : BaseEntity, IOptionEntity
 {
-    private DbSet<TEntity> Set => db.Set<TEntity>();
+    private DbSet<TEntity> Set => dbContext.Set<TEntity>();
 
-    public async Task<TEntity?> Resolve<TModel>(TModel model, CancellationToken ct = default)
+    public async Task<TEntity?> Resolve<TModel>(TModel model, CancellationToken cancellationToken = default)
         where TModel : IOption<TEntity>
     {
         // Nothing to look up and no permission to create.
         if (!model.Create && !model.Id.HasValue)
             return null;
 
-        if (await FindLive(model, ct) is { } live)
+        if (await FindLive(model, cancellationToken) is { } live)
             return live;
 
-        if (await Restore(model, ct) is { } restored)
+        if (await Restore(model, cancellationToken) is { } restored)
             return restored;
 
         return model.Create ? model.ToEntity() : null;
     }
 
-    private async Task<TEntity?> FindLive<TModel>(TModel model, CancellationToken ct)
+    private async Task<TEntity?> FindLive<TModel>(TModel model, CancellationToken cancellationToken)
         where TModel : IOption<TEntity>
     {
         if (model.Id.HasValue &&
-            await Set.FirstOrDefaultAsync(entity => entity.Id == model.Id.Value, ct) is { } byId)
+            await Set.FirstOrDefaultAsync(entity => entity.Id == model.Id.Value, cancellationToken) is { } byId)
             return byId;
 
         if (!string.IsNullOrWhiteSpace(model.Label) &&
-            await Set.FirstOrDefaultAsync(entity => entity.Label == model.Label, ct) is { } byLabel)
+            await Set.FirstOrDefaultAsync(entity => entity.Label == model.Label, cancellationToken) is { } byLabel)
             return byLabel;
 
         return null;
     }
 
     /// <summary>Soft-deleted rows are hidden by the global filter, so look past it and undelete.</summary>
-    private async Task<TEntity?> Restore<TModel>(TModel model, CancellationToken ct)
+    private async Task<TEntity?> Restore<TModel>(TModel model, CancellationToken cancellationToken)
         where TModel : IOption<TEntity>
     {
         var query = Set.IgnoreQueryFilters();
 
         var deleted = model.Id.HasValue
-            ? await query.FirstOrDefaultAsync(entity => entity.Id == model.Id.Value, ct)
-            : await query.FirstOrDefaultAsync(entity => entity.Label == model.Label, ct);
+            ? await query.FirstOrDefaultAsync(entity => entity.Id == model.Id.Value, cancellationToken)
+            : await query.FirstOrDefaultAsync(entity => entity.Label == model.Label, cancellationToken);
 
         if (deleted is not { IsDeleted: true })
             return null;

--- a/src/Xpense/Xpense.Persistence/TypeConfiguration/AccountEntityTypeConfiguration.cs
+++ b/src/Xpense/Xpense.Persistence/TypeConfiguration/AccountEntityTypeConfiguration.cs
@@ -11,14 +11,14 @@ public class AccountEntityTypeConfiguration : BaseEntityTypeConfiguration<Accoun
         base.Configure(builder);
         builder.Metadata.SetSchema(XpenseSchema);
 
-        builder.Property(e => e.Label).HasMaxLength(100).IsRequired();
-        builder.Property(e => e.AccountNumber).HasMaxLength(10).IsRequired().IsFixedLength();
-        builder.Property(e => e.Currency).IsRequired();
+        builder.Property(account => account.Label).HasMaxLength(100).IsRequired();
+        builder.Property(account => account.AccountNumber).HasMaxLength(10).IsRequired().IsFixedLength();
+        builder.Property(account => account.Currency).IsRequired();
 
         // Balance is projected from BalanceMinorUnits + Currency, not stored.
-        builder.Ignore(e => e.Balance);
+        builder.Ignore(account => account.Balance);
 
         // AccountNumber is the public identifier, so it has to be unique.
-        builder.HasIndex(e => e.AccountNumber).IsUnique();
+        builder.HasIndex(account => account.AccountNumber).IsUnique();
     }
 }

--- a/src/Xpense/Xpense.Persistence/TypeConfiguration/BaseEntityTypeConfiguration.cs
+++ b/src/Xpense/Xpense.Persistence/TypeConfiguration/BaseEntityTypeConfiguration.cs
@@ -10,7 +10,7 @@ namespace Xpense.Persistence.TypeConfiguration
 
         public virtual void Configure(EntityTypeBuilder<T> builder)
         {
-            builder.HasKey(e => e.Id);
+            builder.HasKey(entity => entity.Id);
         }
     }
 }

--- a/src/Xpense/Xpense.Persistence/TypeConfiguration/BudgetEntityTypeConfiguration.cs
+++ b/src/Xpense/Xpense.Persistence/TypeConfiguration/BudgetEntityTypeConfiguration.cs
@@ -12,19 +12,19 @@ public class BudgetEntityTypeConfiguration : BaseEntityTypeConfiguration<Budget>
         builder.Metadata.SetSchema(XpenseSchema);
 
         // Amount is projected from AmountMinorUnits and Currency, not stored.
-        builder.Ignore(e => e.Amount);
+        builder.Ignore(budget => budget.Amount);
 
         // Budget (M) - Category (1). No collection on Category: nothing needs to walk that way, and
         // adding one would put a navigation on Category that only this feature reads. Restrict
         // because a category is soft-deleted rather than removed -- DeleteCategory soft-deletes the
         // budgets pointing at it in the same operation.
-        builder.HasOne(e => e.Category)
+        builder.HasOne(budget => budget.Category)
             .WithMany()
-            .HasForeignKey(e => e.CategoryId)
+            .HasForeignKey(budget => budget.CategoryId)
             .OnDelete(DeleteBehavior.Restrict);
 
         // Every read starts from a category and a window.
-        builder.HasIndex(e => new { e.CategoryId, e.StartsOn });
+        builder.HasIndex(budget => new { budget.CategoryId, budget.StartsOn });
 
         // The factory enforces these too. That is not redundancy to remove: a migration, a script or
         // a future caller can write a row without going through it.

--- a/src/Xpense/Xpense.Persistence/TypeConfiguration/CategoryEntityTypeConfiguration.cs
+++ b/src/Xpense/Xpense.Persistence/TypeConfiguration/CategoryEntityTypeConfiguration.cs
@@ -11,11 +11,13 @@ namespace Xpense.Persistence.TypeConfiguration
             base.Configure(builder);
             builder.Metadata.SetSchema(XpenseSchema);
 
-            builder.Property(e => e.Label).HasMaxLength(100).IsRequired();
-            builder.HasIndex(e => e.Label).IsUnique();
+            builder.Property(category => category.Label).HasMaxLength(100).IsRequired();
+            builder.HasIndex(category => category.Label).IsUnique();
 
             // Category (1) - Transaction (M) 
-            builder.HasMany(e => e.Transactions).WithOne(e => e.Category).HasForeignKey(e => e.CategoryId);
+            builder.HasMany(category => category.Transactions)
+                .WithOne(transaction => transaction.Category)
+                .HasForeignKey(transaction => transaction.CategoryId);
         }
     }
 }

--- a/src/Xpense/Xpense.Persistence/TypeConfiguration/MerchantEntityTypeConfiguration.cs
+++ b/src/Xpense/Xpense.Persistence/TypeConfiguration/MerchantEntityTypeConfiguration.cs
@@ -13,12 +13,14 @@ namespace Xpense.Persistence.TypeConfiguration
             builder.Metadata.SetSchema(XpenseSchema);
 
             // Merchant names must be unique
-            builder.HasIndex(e => e.Label).IsUnique();
+            builder.HasIndex(merchant => merchant.Label).IsUnique();
 
-            builder.Property(e => e.Label).HasMaxLength(100).IsRequired();
+            builder.Property(merchant => merchant.Label).HasMaxLength(100).IsRequired();
 
             //  Merchant (M) - Transaction (1)
-            builder.HasMany(e => e.Transactions).WithOne(e => e.Merchant).HasForeignKey(e => e.MerchantId);
+            builder.HasMany(merchant => merchant.Transactions)
+                .WithOne(transaction => transaction.Merchant)
+                .HasForeignKey(transaction => transaction.MerchantId);
         }
     }
 }

--- a/src/Xpense/Xpense.Persistence/TypeConfiguration/PriorityEntityTypeConfiguration.cs
+++ b/src/Xpense/Xpense.Persistence/TypeConfiguration/PriorityEntityTypeConfiguration.cs
@@ -11,12 +11,12 @@ namespace Xpense.Persistence.TypeConfiguration
             base.Configure(builder);
             builder.Metadata.SetSchema(XpenseSchema);
 
-            builder.HasIndex(e => e.Label).IsUnique();
+            builder.HasIndex(priority => priority.Label).IsUnique();
 
-            builder.Property(e => e.Label).HasMaxLength(100).IsRequired();
+            builder.Property(priority => priority.Label).HasMaxLength(100).IsRequired();
 
             // PriorityId (1) - Category (M)
-            builder.HasMany(p => p.Categories).WithOne(c => c.Priority).HasForeignKey(c => c.PriorityId);
+            builder.HasMany(priority => priority.Categories).WithOne(category => category.Priority).HasForeignKey(category => category.PriorityId);
 
             SeedPriorities(builder);
         }

--- a/src/Xpense/Xpense.Persistence/TypeConfiguration/TagEntityTypeConfiguration.cs
+++ b/src/Xpense/Xpense.Persistence/TypeConfiguration/TagEntityTypeConfiguration.cs
@@ -11,18 +11,18 @@ public class TagEntityTypeConfiguration : BaseEntityTypeConfiguration<Tag>
         base.Configure(builder);
         builder.Metadata.SetSchema(XpenseSchema);
 
-        builder.Property(e => e.Label).HasMaxLength(100).IsRequired();
-        builder.Property(e => e.BgColorHex).HasMaxLength(6).IsFixedLength();
-        builder.Property(e => e.FgColorHex).HasMaxLength(6).IsFixedLength();
+        builder.Property(tag => tag.Label).HasMaxLength(100).IsRequired();
+        builder.Property(tag => tag.BgColorHex).HasMaxLength(6).IsFixedLength();
+        builder.Property(tag => tag.FgColorHex).HasMaxLength(6).IsFixedLength();
 
         // Tag Name Index
-        builder.HasIndex(e => e.Label).IsUnique();
+        builder.HasIndex(tag => tag.Label).IsUnique();
 
         // Tags (M) - Transactions (M)
-        builder.HasMany(e => e.Transactions).WithMany(e => e.Tags).UsingEntity("TransactionTags",
-           l => l.HasOne(typeof(Transaction)).WithMany().HasForeignKey("TransactionId").HasPrincipalKey(nameof(Transaction.Id)),
-           r => r.HasOne(typeof(Tag)).WithMany().HasForeignKey("TagId").HasPrincipalKey(nameof(Tag.Id)),
-           j => j.HasKey("TagId", "TransactionId")
+        builder.HasMany(tag => tag.Transactions).WithMany(transaction => transaction.Tags).UsingEntity("TransactionTags",
+           transactionSide => transactionSide.HasOne(typeof(Transaction)).WithMany().HasForeignKey("TransactionId").HasPrincipalKey(nameof(Transaction.Id)),
+           tagSide => tagSide.HasOne(typeof(Tag)).WithMany().HasForeignKey("TagId").HasPrincipalKey(nameof(Tag.Id)),
+           joinEntity => joinEntity.HasKey("TagId", "TransactionId")
         );
     }
 }

--- a/src/Xpense/Xpense.Persistence/TypeConfiguration/TransactionEntityTypeConfiguration.cs
+++ b/src/Xpense/Xpense.Persistence/TypeConfiguration/TransactionEntityTypeConfiguration.cs
@@ -12,37 +12,41 @@ public class TransactionEntityTypeConfiguration : BaseEntityTypeConfiguration<Tr
         builder.Metadata.SetSchema(XpenseSchema);
 
         // Amount and Kind are projected, not stored.
-        builder.Ignore(e => e.Amount);
-        builder.Ignore(e => e.Kind);
+        builder.Ignore(transaction => transaction.Amount);
+        builder.Ignore(transaction => transaction.Kind);
 
-        builder.Property(e => e.Reason).HasMaxLength(500);
+        builder.Property(transaction => transaction.Reason).HasMaxLength(500);
 
         // Two nullable sides. A null side means the money crossed the system boundary; there is no
         // collection navigation on Account because one collection cannot express two foreign keys.
-        builder.HasOne(e => e.SourceAccount)
+        builder.HasOne(transaction => transaction.SourceAccount)
             .WithMany()
-            .HasForeignKey(e => e.SourceAccountId)
+            .HasForeignKey(transaction => transaction.SourceAccountId)
             .OnDelete(DeleteBehavior.Restrict);
 
-        builder.HasOne(e => e.DestinationAccount)
+        builder.HasOne(transaction => transaction.DestinationAccount)
             .WithMany()
-            .HasForeignKey(e => e.DestinationAccountId)
+            .HasForeignKey(transaction => transaction.DestinationAccountId)
             .OnDelete(DeleteBehavior.Restrict);
 
         // Transaction (M) - Category(1), optional: a transfer has no spending class.
-        builder.HasOne(e => e.Category).WithMany(e => e.Transactions).HasForeignKey(e => e.CategoryId);
+        builder.HasOne(transaction => transaction.Category)
+            .WithMany(category => category.Transactions)
+            .HasForeignKey(transaction => transaction.CategoryId);
 
         // Transaction (M) - Merchant(1), optional: a transfer has no external party.
-        builder.HasOne(e => e.Merchant).WithMany(e => e.Transactions).HasForeignKey(e => e.MerchantId);
+        builder.HasOne(transaction => transaction.Merchant)
+            .WithMany(merchant => merchant.Transactions)
+            .HasForeignKey(transaction => transaction.MerchantId);
 
         // Transaction (M) - Tag(M)
         builder
-            .HasMany(e => e.Tags)
-            .WithMany(e => e.Transactions)
+            .HasMany(transaction => transaction.Tags)
+            .WithMany(tag => tag.Transactions)
             .UsingEntity("TransactionTags",
-               l => l.HasOne(typeof(Tag)).WithMany().HasForeignKey("TagId").HasPrincipalKey(nameof(Tag.Id)),
-               r => r.HasOne(typeof(Transaction)).WithMany().HasForeignKey("TransactionId").HasPrincipalKey(nameof(Transaction.Id)),
-               j => j.HasKey("TransactionId", "TagId")
+               tagSide => tagSide.HasOne(typeof(Tag)).WithMany().HasForeignKey("TagId").HasPrincipalKey(nameof(Tag.Id)),
+               transactionSide => transactionSide.HasOne(typeof(Transaction)).WithMany().HasForeignKey("TransactionId").HasPrincipalKey(nameof(Transaction.Id)),
+               joinEntity => joinEntity.HasKey("TransactionId", "TagId")
             );
 
         // The factories on Transaction enforce this, but they are not the only way a row can be

--- a/src/Xpense/Xpense.Persistence/XpenseDbContext.cs
+++ b/src/Xpense/Xpense.Persistence/XpenseDbContext.cs
@@ -26,7 +26,7 @@ namespace Xpense.Persistence
             modelBuilder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
             ConfigureDecimalColumnsStore(modelBuilder, 18, 2);
             ConfigureUtcDateTimes(modelBuilder);
-            ApplyGlobalQueryFilter(modelBuilder, s => !s.IsDeleted);
+            ApplyGlobalQueryFilter(modelBuilder, entity => !entity.IsDeleted);
             base.OnModelCreating(modelBuilder);
         }
 
@@ -83,8 +83,8 @@ namespace Xpense.Persistence
         {
             var decimalColumns = modelBuilder.Model
                 .GetEntityTypes()
-                .SelectMany(t => t.GetProperties())
-                .Where(p => p.ClrType == typeof(decimal) || p.ClrType == typeof(decimal?));
+                .SelectMany(entityType => entityType.GetProperties())
+                .Where(property => property.ClrType == typeof(decimal) || property.ClrType == typeof(decimal?));
 
             foreach (var decimalProperty in decimalColumns)
             {

--- a/src/Xpense/Xpense.Tests/Integration/ApiEndpointTests.cs
+++ b/src/Xpense/Xpense.Tests/Integration/ApiEndpointTests.cs
@@ -617,11 +617,11 @@ public class ApiEndpointTests
 
         using (var scope = failing.Services.CreateScope())
         {
-            var db = scope.ServiceProvider.GetRequiredService<XpenseDbContext>();
-            db.Accounts.AddRange(
+            var dbContext = scope.ServiceProvider.GetRequiredService<XpenseDbContext>();
+            dbContext.Accounts.AddRange(
                 NewAccount(SourceNumber, "Source", 2000),
                 NewAccount(DestinationNumber, "Destination", 300));
-            await db.SaveChangesAsync();
+            await dbContext.SaveChangesAsync();
         }
 
         var response = await failingClient.PostAsJsonAsync("/api/v1/transactions", new
@@ -635,9 +635,9 @@ public class ApiEndpointTests
 
         using var verification = failing.Services.CreateScope();
         var verifyDb = verification.ServiceProvider.GetRequiredService<XpenseDbContext>();
-        (await verifyDb.Accounts.AsNoTracking().SingleAsync(a => a.AccountNumber == SourceNumber))
+        (await verifyDb.Accounts.AsNoTracking().SingleAsync(account => account.AccountNumber == SourceNumber))
             .BalanceMinorUnits.Should().Be(2000);
-        (await verifyDb.Accounts.AsNoTracking().SingleAsync(a => a.AccountNumber == DestinationNumber))
+        (await verifyDb.Accounts.AsNoTracking().SingleAsync(account => account.AccountNumber == DestinationNumber))
             .BalanceMinorUnits.Should().Be(300);
         (await verifyDb.Transactions.CountAsync()).Should().Be(0);
     }


### PR DESCRIPTION
`ct` → `cancellationToken`, `db` → `dbContext`, `http` → `httpContext`, and every single-letter lambda parameter named for what it holds.

`app` stays — it is the framework's own name for that thing, in every ASP.NET template and minimal-API doc.

## Lambdas are named for their own type

This is the part a blind find-and-replace gets wrong. In relationship configuration the two sides are different types:

```csharp
builder.HasOne(transaction => transaction.Category)
    .WithMany(category => category.Transactions)      // a Category, not a Transaction
    .HasForeignKey(transaction => transaction.CategoryId);
```

A blanket rename called all three `transaction`. That compiles — parameter names are arbitrary — and then actively misleads, which is worse than the `e` it replaced. All six such sites are named by their real type here.

The Transaction/Tag join names its three lambdas by role instead of `l`, `r`, `j`:

```csharp
.UsingEntity("TransactionTags",
   tagSide         => tagSide.HasOne(typeof(Tag))...,
   transactionSide => transactionSide.HasOne(typeof(Transaction))...,
   joinEntity      => joinEntity.HasKey("TransactionId", "TagId"));
```

## String literals are skipped

Learned the hard way. A naive `\bhttp\b` rewrote `"http://localhost:5173"` to `"httpContext://localhost:5173"`, silently breaking the CORS origin. The rename here splits each file on string literals and only rewrites the code between them, and the result is grepped to confirm no literal was touched.

## Verified

No behaviour change. Build warning-free, 105 tests pass, and zero single-letter lambdas remain.

~30 files, all mechanical. Stacked; **base is `refactor/validation-messages`** (#51).