### PR TITLE
refactor: keep only the comments Swagger reads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,17 @@ These are enforced by `Xpense.Tests/Architecture/SliceIsolationTests.cs`. Breaki
 
 `GET /health` is the one deliberate exception: it is mapped directly in `Program.cs` because it is infrastructure, not a feature. It has no request, no contract to version and no slice to belong to. The architecture tests allow it — they constrain types under `Xpense.API.Features.*` and types implementing `IEndpoint`, and it is neither. Do not treat it as precedent for a second one.
 
+## Pinned packages
+
+Three versions are held deliberately. Bumping any of them needs a reason.
+
+- **FluentAssertions stays on 6.x.** Version 8 moved to a commercial Xceed licence.
+- **`Microsoft.EntityFrameworkCore.Relational` is pinned explicitly.** Npgsql floors it at `[10.0.4, 11.0.0)`, so without a pin NuGet resolves 10.0.4 against a 10.0.10 core and the app fails at runtime with a missing assembly. See [`docs/postgres.md`](docs/postgres.md).
+- **`dotnet-ef` is a local tool** in `.config/dotnet-tools.json`, matching the EF runtime. A globally installed 8.x tool refuses to run against EF 10.
+
 ## Style
 
+- **No comments.** Not in C#, Dockerfiles, YAML, XML or shell. The one exception is `<summary>` on `*Request` and `*Response` records, because Swagger renders those into the OpenAPI document that [ADR 0003](docs/adr/0003-generated-openapi-is-the-contract.md) makes authoritative. Write code that says what it does and put reasoning in the commit message, an ADR, or `docs/`. Parser directives that only look like comments stay: `# syntax=` in a Dockerfile, `#!` in a script.
 - **Spell names out.** `cancellationToken`, not `ct`. `dbContext`, not `db`. `httpContext`, not `http`. Lambda parameters are named for what they hold, and for *their own* type -- in relationship configuration the two sides differ, so `HasOne(transaction => transaction.Category).WithMany(category => category.Transactions)`. `app` in `Map(IEndpointRouteBuilder app)` is the one exception, being the framework's own name for that thing.
 - **Constants first.** `const` and `static readonly` go at the top of the type, before fields, properties and methods.
 - **Validation messages are prose, not identifiers.** "The category must be a valid selection", never "The categoryId must reference an existing category". The ProblemDetails error dictionary is already keyed by the camelCase field, which is how a client attaches an error to an input, so the message is free to read like a sentence. Domain words stay: "minor units" is the term, per [`UBIQUITOUS_LANGUAGE.md`](UBIQUITOUS_LANGUAGE.md).

--- a/src/Xpense/Xpense.API/Contracts/Timestamps.cs
+++ b/src/Xpense/Xpense.API/Contracts/Timestamps.cs
@@ -2,16 +2,6 @@ using System;
 
 namespace Xpense.API.Contracts;
 
-/// <summary>
-/// Every timestamp crosses the boundary as an ISO 8601 UTC string, per
-/// docs/contract/api-v1-contract-design.md.
-/// <para>
-/// Shared because accounts, transactions, categories, priorities, tags and merchants all return
-/// timestamps and they must look identical in each. Before this, accounts, categories, priorities,
-/// tags and merchants returned unix seconds while transactions returned ISO 8601 -- one concept in
-/// two formats, and the contract doc only described one of them.
-/// </para>
-/// </summary>
 public static class Timestamps
 {
     public static string Iso(DateTime value) =>

--- a/src/Xpense/Xpense.API/ExceptionHandlers/DomainRuleViolationExceptionHandler.cs
+++ b/src/Xpense/Xpense.API/ExceptionHandlers/DomainRuleViolationExceptionHandler.cs
@@ -7,10 +7,6 @@ using Xpense.Domain.Exceptions;
 
 namespace Xpense.API.ExceptionHandlers;
 
-/// <summary>
-/// Handles <see cref="DomainRuleViolationException"/>. The request was well-formed but breaks a
-/// domain rule, so the caller can fix it by changing the request.
-/// </summary>
 public sealed class DomainRuleViolationExceptionHandler(IProblemDetailsService problemDetailsService) : IExceptionHandler
 {
     public ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)

--- a/src/Xpense/Xpense.API/ExceptionHandlers/FallbackExceptionHandler.cs
+++ b/src/Xpense/Xpense.API/ExceptionHandlers/FallbackExceptionHandler.cs
@@ -7,10 +7,6 @@ using Serilog;
 
 namespace Xpense.API.ExceptionHandlers;
 
-/// <summary>
-/// Last handler in the chain. Anything not claimed by a more specific handler becomes a 500
-/// with a generic detail so internals never reach the client.
-/// </summary>
 public sealed class FallbackExceptionHandler(
     IProblemDetailsService problemDetailsService,
     ILogger logger) : IExceptionHandler

--- a/src/Xpense/Xpense.API/ExceptionHandlers/InsufficientFundsExceptionHandler.cs
+++ b/src/Xpense/Xpense.API/ExceptionHandlers/InsufficientFundsExceptionHandler.cs
@@ -9,11 +9,6 @@ using Xpense.Domain.Exceptions;
 
 namespace Xpense.API.ExceptionHandlers;
 
-/// <summary>
-/// Special case ahead of <see cref="DomainRuleViolationExceptionHandler"/>. Still a 400, but
-/// the failure is attributable to a specific field, so it is reported as a field error rather
-/// than a flat problem detail.
-/// </summary>
 public sealed class InsufficientFundsExceptionHandler(IProblemDetailsService problemDetailsService) : IExceptionHandler
 {
     public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)

--- a/src/Xpense/Xpense.API/ExceptionHandlers/NotFoundExceptionHandler.cs
+++ b/src/Xpense/Xpense.API/ExceptionHandlers/NotFoundExceptionHandler.cs
@@ -7,7 +7,6 @@ using Xpense.Domain.Exceptions;
 
 namespace Xpense.API.ExceptionHandlers;
 
-/// <summary>Handles <see cref="NotFoundException"/>. A resource was looked up by identity and does not exist.</summary>
 public sealed class NotFoundExceptionHandler(IProblemDetailsService problemDetailsService) : IExceptionHandler
 {
     public ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)

--- a/src/Xpense/Xpense.API/ExceptionHandlers/PersistenceFailedExceptionHandler.cs
+++ b/src/Xpense/Xpense.API/ExceptionHandlers/PersistenceFailedExceptionHandler.cs
@@ -8,10 +8,6 @@ using Xpense.Domain.Exceptions;
 
 namespace Xpense.API.ExceptionHandlers;
 
-/// <summary>
-/// Handles <see cref="PersistenceFailedException"/>. A write we expected to succeed did not.
-/// The caller cannot fix this, so the detail stays generic and the cause goes to the log.
-/// </summary>
 public sealed class PersistenceFailedExceptionHandler(
     IProblemDetailsService problemDetailsService,
     ILogger logger) : IExceptionHandler

--- a/src/Xpense/Xpense.API/ExceptionHandlers/ProblemDetailsWriter.cs
+++ b/src/Xpense/Xpense.API/ExceptionHandlers/ProblemDetailsWriter.cs
@@ -5,10 +5,6 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Xpense.API.ExceptionHandlers;
 
-/// <summary>
-/// Shared plumbing for the exception handlers. Each handler decides the status, title and
-/// detail; this writes the RFC 7807 payload so every error response has the same shape.
-/// </summary>
 internal static class ProblemDetailsWriter
 {
     public static async ValueTask<bool> Write(
@@ -35,11 +31,6 @@ internal static class ProblemDetailsWriter
         });
     }
 
-    /// <summary>
-    /// FluentValidation reports PascalCase property paths ("Amount.Cents"); the JSON contract
-    /// is camelCase ("amount.cents"). Convert each dotted segment so the error keys line up
-    /// with the field names the client actually sent.
-    /// </summary>
     public static string ToCamelCasePath(string propertyPath)
     {
         if (string.IsNullOrEmpty(propertyPath))

--- a/src/Xpense/Xpense.API/ExceptionHandlers/ValidationExceptionHandler.cs
+++ b/src/Xpense/Xpense.API/ExceptionHandlers/ValidationExceptionHandler.cs
@@ -10,10 +10,6 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Xpense.API.ExceptionHandlers;
 
-/// <summary>
-/// Handles FluentValidation's <see cref="ValidationException"/>, thrown by
-/// <see cref="Infrastructure.ValidationEndpointFilter"/> when a request DTO fails its validator.
-/// </summary>
 public sealed class ValidationExceptionHandler(IProblemDetailsService problemDetailsService) : IExceptionHandler
 {
     public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)

--- a/src/Xpense/Xpense.API/Extensions/IoC.cs
+++ b/src/Xpense/Xpense.API/Extensions/IoC.cs
@@ -25,29 +25,16 @@ public static class IoC
         });
     }
 
-    /// <summary>
-    /// What is left after the migration to slices: one open generic. The 31 AddScoped calls
-    /// that registered a class per use case are gone -- slices are discovered, not registered.
-    /// </summary>
     public static void AddDomainServices(this IServiceCollection services)
     {
         services.AddScoped(typeof(OptionResolver<>));
     }
 
-    /// <summary>
-    /// Validators live nested inside their slice, so scan the whole assembly rather than
-    /// naming a marker type that moves every time a feature is restructured.
-    /// </summary>
     public static void AddRequestValidation(this IServiceCollection services)
     {
         services.AddValidatorsFromAssembly(typeof(IEndpoint).Assembly);
     }
 
-    /// <summary>
-    /// One handler per exception type. Order is significant: the first handler that claims an
-    /// exception wins, so specific cases are registered ahead of the base type they derive
-    /// from, and the catch-all goes last.
-    /// </summary>
     public static void AddExceptionHandlers(this IServiceCollection services)
     {
         services.AddProblemDetails();
@@ -60,10 +47,6 @@ public static class IoC
         services.AddExceptionHandler<FallbackExceptionHandler>();
     }
 
-    /// <summary>
-    /// One probe, and it asks the only question worth asking: can this process reach Postgres.
-    /// A liveness/readiness split would be machinery for an orchestrator this project does not have.
-    /// </summary>
     public static void AddHealthProbe(this IServiceCollection services)
     {
         services.AddHealthChecks().AddDbContextCheck<XpenseDbContext>();
@@ -82,7 +65,6 @@ public static class IoC
                     Version = "v1",
                     Title = "Xpense.API",
                     Description = "Financial Tracker and advisor",
-                    // TODO: Add Terms of Use
                     Contact = new OpenApiContact
                     {
                         Name = "Mohamed Halawa",
@@ -91,16 +73,11 @@ public static class IoC
                     },
                 });
 
-            // Read XML Comments Generated Document
             var xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
             options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename));
         });
     }
 
-    /// <summary>
-    /// A schema id that is unique for a nested type: every name it is declared inside, outermost first,
-    /// then its own. <c>CreateBudget.Request</c> becomes <c>CreateBudgetRequest</c>.
-    /// </summary>
     private static string SchemaId(Type type)
     {
         var names = new List<string>();
@@ -108,7 +85,6 @@ public static class IoC
         for (var current = type; current is not null; current = current.DeclaringType)
             names.Insert(0, current.Name);
 
-        // Generics arrive as `Thing`1`; the arity suffix is not valid in a schema id.
         return string.Concat(names).Replace("`", string.Empty);
     }
 }

--- a/src/Xpense/Xpense.API/Features/Accounts/CreateAccount.cs
+++ b/src/Xpense/Xpense.API/Features/Accounts/CreateAccount.cs
@@ -18,7 +18,6 @@ namespace Xpense.API.Features.Accounts;
 
 public sealed class CreateAccount : IEndpoint
 {
-    /// <summary>Account number allocated to the very first account.</summary>
     private const long FirstAccountNumber = 1_000_000_000;
 
     /// <summary>
@@ -83,17 +82,6 @@ public sealed class CreateAccount : IEndpoint
             AccountResponse.Of(account));
     }
 
-    /// <summary>
-    /// AccountRepository.GetNextAccountNumber called Max() on the parsed numbers, which threw
-    /// InvalidOperationException on an empty table -- creating the very first account crashed.
-    /// Tests never caught it because they always seeded an account first.
-    /// <para>
-    /// ponytail: still loads every number to take the maximum. That races under concurrent creates
-    /// and grows with the table, and it makes the public identifier guessable -- which starts to
-    /// matter once a cross-user transfer can write to an account named by number. Both belong with
-    /// the ownership work; see docs/model-rename-pass.md.
-    /// </para>
-    /// </summary>
     private static async Task<string> NextAccountNumber(XpenseDbContext dbContext, CancellationToken cancellationToken)
     {
         var numbers = await dbContext.Accounts.Select(account => account.AccountNumber).ToListAsync(cancellationToken);

--- a/src/Xpense/Xpense.API/Features/Analytics/GetSpendingByCategory.cs
+++ b/src/Xpense/Xpense.API/Features/Analytics/GetSpendingByCategory.cs
@@ -24,12 +24,8 @@ public sealed class GetSpendingByCategory : IEndpoint
         XpenseDbContext dbContext,
         CancellationToken cancellationToken)
     {
-        // Timestamps are stored UTC, so "today" is a UTC day.
         var today = DateTime.UtcNow.Date;
 
-        // Expenses only, and the filter has to be expressed as columns because Kind is computed.
-        // Transfers would have no category to group by, and income is not spending -- it used to be
-        // counted here, because nothing filtered by direction at all.
         var expensesToday = await dbContext.Transactions
             .AsNoTracking()
             .Include(transaction => transaction.Category)
@@ -39,9 +35,6 @@ public sealed class GetSpendingByCategory : IEndpoint
                                   && transaction.OccurredAt.Date == today)
             .ToListAsync(cancellationToken);
 
-        // Grouped by currency as well as by category, because nothing converts. This used to label
-        // the whole total with expensesToday[0].Currency and sum minor units across every currency
-        // in the day, so 10 EUR and 10 USD reported as 2000 EUR -- money invented by addition.
         var byCategory = expensesToday
             .GroupBy(transaction => new { transaction.Category!.Id, transaction.Currency })
             .Select(group => new CategorySpendingResponse(
@@ -52,8 +45,6 @@ public sealed class GetSpendingByCategory : IEndpoint
             .ThenBy(spending => spending.Amount.Currency)
             .ToArray();
 
-        // One total per currency present. An empty day has no currency to speak for, so it has no
-        // totals rather than a zero in a currency nobody used.
         var totals = expensesToday
             .GroupBy(transaction => transaction.Currency)
             .Select(group => new MoneyResponse(group.Sum(transaction => transaction.AmountMinorUnits), group.Key.ToString()))

--- a/src/Xpense/Xpense.API/Features/Budgets/CreateBudget.cs
+++ b/src/Xpense/Xpense.API/Features/Budgets/CreateBudget.cs
@@ -16,11 +16,6 @@ using Xpense.Persistence;
 
 namespace Xpense.API.Features.Budgets;
 
-/// <summary>
-/// States a budget. Nothing checks it against any other budget: several may cover one category at
-/// once and Xpense does not arbitrate, per
-/// docs/adr/0007-budgets-are-independent-of-one-another.md.
-/// </summary>
 public sealed class CreateBudget : IEndpoint
 {
     public sealed record Request(
@@ -56,9 +51,6 @@ public sealed class CreateBudget : IEndpoint
                 .Must(recurrence => RecurrenceParser.TryParse(recurrence, out _))
                 .WithMessage("The recurrence must be one of None, Weekly, Monthly or Yearly.");
 
-            // Both of these are guarded in Budget as well. That is not redundancy to remove: this
-            // produces a good 400 for a bad request, and the domain guard makes the state
-            // unreachable through any future caller.
             RuleFor(request => request.EndsOn)
                 .NotNull()
                 .When(request => IsOneOff(request.Recurrence))
@@ -102,8 +94,6 @@ public sealed class CreateBudget : IEndpoint
         if (await dbContext.SaveChangesAsync(cancellationToken) < 1)
             throw new BudgetCreationFailedException(request.CategoryId);
 
-        // A freshly stated budget has measured nothing worth reporting yet, and the caller asked to
-        // create rather than to read, so no period is computed here.
         return TypedResults.Created(
             httpContext.ResourceUri($"/api/v1/budgets/{budget.Id}"),
             BudgetResponse.Of(budget, null));

--- a/src/Xpense/Xpense.API/Features/Budgets/GetBudgetById.cs
+++ b/src/Xpense/Xpense.API/Features/Budgets/GetBudgetById.cs
@@ -14,14 +14,6 @@ using Xpense.Persistence;
 
 namespace Xpense.API.Features.Budgets;
 
-/// <summary>
-/// One budget and what it has measured over one of its periods.
-/// <para>
-/// Unlike <see cref="ListBudgets"/>, the totals are summed in the database and grouped by currency
-/// there: with a single budget there is one window to ask about, so nothing has to be sorted out in
-/// memory afterwards.
-/// </para>
-/// </summary>
 public sealed class GetBudgetById : IEndpoint
 {
     public static void Map(IEndpointRouteBuilder app) =>
@@ -62,8 +54,6 @@ public sealed class GetBudgetById : IEndpoint
             })
             .ToListAsync(cancellationToken);
 
-        // Built in the budget's own currency: Money.Zero is EUR, and a EUR zero taken from a USD
-        // limit throws instead of returning the limit untouched.
         var spent = Money.OfMinorUnits(
             totals.SingleOrDefault(total => total.Currency == budget.Currency)?.MinorUnits ?? 0,
             budget.Currency);

--- a/src/Xpense/Xpense.API/Features/Budgets/ListBudgets.cs
+++ b/src/Xpense/Xpense.API/Features/Budgets/ListBudgets.cs
@@ -15,15 +15,6 @@ using Xpense.Persistence;
 
 namespace Xpense.API.Features.Budgets;
 
-/// <summary>
-/// Every budget with what it has measured so far, ready for a dashboard in one request.
-/// <para>
-/// Spending is fetched with a single query covering every budget in the list rather than one query
-/// per budget, so ten budgets cost two round trips and not eleven. The window asked for spans the
-/// earliest period start to the latest period end, which over-fetches when a weekly budget and a
-/// yearly one appear together -- one wide filtered read beats N narrow ones.
-/// </para>
-/// </summary>
 public sealed class ListBudgets : IEndpoint
 {
     public static void Map(IEndpointRouteBuilder app) =>
@@ -34,7 +25,6 @@ public sealed class ListBudgets : IEndpoint
         CancellationToken cancellationToken,
         DateTimeOffset? on = null)
     {
-        // Which period a budget is in depends on a moment. Default to now; `?on=` asks about another.
         var instant = on?.UtcDateTime ?? DateTime.UtcNow;
 
         var budgets = await dbContext.Budgets
@@ -58,8 +48,6 @@ public sealed class ListBudgets : IEndpoint
         var from = active.Min(entry => entry.Period!.From);
         var toExclusive = active.Max(entry => entry.Period!.ToExclusive);
 
-        // Expenses only, and the filter is written as columns because Kind is computed. A transfer
-        // has no category to count against, and income is not spending.
         var expenses = await dbContext.Transactions
             .AsNoTracking()
             .Where(transaction => transaction.SourceAccountId != null
@@ -94,8 +82,6 @@ public sealed class ListBudgets : IEndpoint
             .Where(expense => expense.CategoryId == categoryId && period.Contains(expense.OccurredAt))
             .ToArray();
 
-        // Zero has to be built in this budget's currency. Money.Zero is EUR, and subtracting a EUR
-        // zero from a USD limit throws rather than returning the limit.
         var spent = Money.OfMinorUnits(
             inPeriod.Where(expense => expense.Currency == limit.Currency).Sum(expense => expense.MinorUnits),
             limit.Currency);

--- a/src/Xpense/Xpense.API/Features/Budgets/UpdateBudget.cs
+++ b/src/Xpense/Xpense.API/Features/Budgets/UpdateBudget.cs
@@ -15,10 +15,6 @@ using Xpense.Persistence;
 
 namespace Xpense.API.Features.Budgets;
 
-/// <summary>
-/// Restates a budget's limit and window. The category is not among them: a budget for a different
-/// category is a different budget, the same way an account's currency is fixed for its life.
-/// </summary>
 public sealed class UpdateBudget : IEndpoint
 {
     public sealed record Request(

--- a/src/Xpense/Xpense.API/Features/Categories/DeleteCategory.cs
+++ b/src/Xpense/Xpense.API/Features/Categories/DeleteCategory.cs
@@ -19,19 +19,12 @@ public sealed class DeleteCategory : IEndpoint
 
     private static async Task<NoContent> Handle(int id, XpenseDbContext dbContext, CancellationToken cancellationToken)
     {
-        // CategoryRepository.DeleteById wrapped a FirstAsync in catch-all and rethrew as
-        // CategoryNotFoundException. Same outcome, without swallowing unrelated failures.
         var category = await dbContext.Categories.FirstOrDefaultAsync(item => item.Id == id, cancellationToken)
                        ?? throw new CategoryNotFoundException(id);
 
         category.MarkAsDeleted();
         category.Touch();
 
-        // A budget on a category nobody can see measures nothing anyone can ask about, so it goes
-        // with it. This also keeps budget reads from ever meeting a null category: the global query
-        // filter hides the row, and an Include would hand back null for a category that is still
-        // referenced. Budget is an entity rather than another slice's type, so reaching it from here
-        // does not cross a slice boundary.
         var budgets = await dbContext.Budgets.Where(budget => budget.CategoryId == id).ToListAsync(cancellationToken);
 
         foreach (var budget in budgets)

--- a/src/Xpense/Xpense.API/Features/Priorities/ListPriorities.cs
+++ b/src/Xpense/Xpense.API/Features/Priorities/ListPriorities.cs
@@ -12,14 +12,6 @@ using Xpense.Persistence;
 
 namespace Xpense.API.Features.Priorities;
 
-/// <summary>
-/// The priorities a category can be given. Read-only: they are reference data, seeded by a migration
-/// rather than created through the API.
-/// <para>
-/// This exists because a category requires a priority id and nothing exposed the ids. A client had
-/// to hardcode 1 to 5 and hope the seed never changed.
-/// </para>
-/// </summary>
 public sealed class ListPriorities : IEndpoint
 {
     public static void Map(IEndpointRouteBuilder app) =>
@@ -27,8 +19,6 @@ public sealed class ListPriorities : IEndpoint
 
     private static async Task<Ok<PriorityResponse[]>> Handle(XpenseDbContext dbContext, CancellationToken cancellationToken)
     {
-        // By id, which is seed order: Extreme, High, Medium, Low, None. Weight would put None first,
-        // because None weighs 0 and Extreme weighs 1.
         var priorities = await dbContext.Priorities
             .AsNoTracking()
             .OrderBy(priority => priority.Id)

--- a/src/Xpense/Xpense.API/Features/Tags/DeleteTag.cs
+++ b/src/Xpense/Xpense.API/Features/Tags/DeleteTag.cs
@@ -21,8 +21,6 @@ public sealed class DeleteTag : IEndpoint
         var tag = await dbContext.Tags.FirstOrDefaultAsync(tag => tag.Id == id, cancellationToken)
                   ?? throw new TagNotFoundException(id);
 
-        // Soft delete: the global query filter hides IsDeleted rows. Preserved from the
-        // repository's Delete, which did exactly this rather than removing the row.
         tag.MarkAsDeleted();
         tag.Touch();
 

--- a/src/Xpense/Xpense.API/Features/Tags/TagRules.cs
+++ b/src/Xpense/Xpense.API/Features/Tags/TagRules.cs
@@ -4,13 +4,11 @@ namespace Xpense.API.Features.Tags;
 
 internal static class TagColour
 {
-    /// <summary>Colours are accepted with or without a leading '#'; stored without.</summary>
     public static string Normalise(string hex) => hex?.TrimStart('#');
 }
 
 internal static class TagRules
 {
-    /// <summary>Shared by CreateTag and UpdateTag, which both validate the same two colours.</summary>
     public static IRuleBuilderOptions<T, string> HexColour<T>(
         this IRuleBuilder<T, string> rule,
         string fieldName)

--- a/src/Xpense/Xpense.API/Features/Tags/UpdateTag.cs
+++ b/src/Xpense/Xpense.API/Features/Tags/UpdateTag.cs
@@ -38,8 +38,6 @@ public sealed class UpdateTag : IEndpoint
         XpenseDbContext dbContext,
         CancellationToken cancellationToken)
     {
-        // The old UpdateTagUseCase dereferenced the entity without a null check and threw
-        // NullReferenceException for a missing id.
         var tag = await dbContext.Tags.FirstOrDefaultAsync(tag => tag.Id == id, cancellationToken)
                   ?? throw new TagNotFoundException(id);
 

--- a/src/Xpense/Xpense.API/Features/Transactions/CreateTransaction.cs
+++ b/src/Xpense/Xpense.API/Features/Transactions/CreateTransaction.cs
@@ -19,16 +19,6 @@ using Xpense.Domain.ValueObjects;
 
 namespace Xpense.API.Features.Transactions;
 
-/// <summary>
-/// One endpoint for all three kinds. Which sides the caller names decides the kind, so there is no
-/// type field to contradict them: naming only a destination is income, only a source is expense,
-/// both is a transfer. This replaced a separate /transfers resource over the same entity.
-/// <para>
-/// The caller must name at least one account. The default-account fallback that the old
-/// income/expense endpoint had is gone: it relied on a type field to know which side the default
-/// account stood in for, and that field no longer exists.
-/// </para>
-/// </summary>
 public sealed class CreateTransaction : IEndpoint
 {
     public sealed record Request(
@@ -68,8 +58,6 @@ public sealed class CreateTransaction : IEndpoint
                     "Either a source account or a destination account is required.")
                 .WithName(nameof(Request.SourceAccountNumber));
 
-            // A transaction with one account inside Xpense has a counterparty outside it, which the
-            // merchant names, and a spending class. A transfer has neither: no shop, no spending.
             When(IsOneSided, () =>
             {
                 RuleFor(request => request.CategoryId)
@@ -88,9 +76,6 @@ public sealed class CreateTransaction : IEndpoint
                 RuleFor(request => request.Merchant)
                     .Null().WithMessage("A transfer between two accounts cannot have a merchant.");
 
-                // Also guarded in the domain. That is not redundancy to remove: this produces a
-                // good 400 for a bad request, and the domain guard makes the move impossible
-                // through any future caller.
                 RuleFor(request => request.DestinationAccountNumber)
                     .Must((request, destination) =>
                         !string.Equals(request.SourceAccountNumber, destination, StringComparison.Ordinal))
@@ -118,23 +103,15 @@ public sealed class CreateTransaction : IEndpoint
         HttpContext httpContext,
         CancellationToken cancellationToken)
     {
-        // The validator already rejected anything else.
         CurrencyParser.TryParse(request.Amount.Currency, out var currency);
 
         var amount = Money.OfMinorUnits(request.Amount.MinorUnits, currency);
         var occurredAt = request.OccurredAt?.UtcDateTime ?? DateTime.UtcNow;
 
-        // Serializable because every kind reads a balance and writes it back. The old transfer
-        // endpoint isolated this and the old income/expense endpoint did not; one path means one
-        // answer, and the safer one is the correct one.
         await using var scope = await dbContext.Database.BeginTransactionAsync(IsolationLevel.Serializable, cancellationToken);
 
         try
         {
-            // Loaded inside the transaction, not before it. Postgres only detects conflicts on
-            // reads made within the transaction, so a balance read outside it leaves the
-            // insufficient-funds guard unprotected: two concurrent transfers from one account would
-            // both see the old balance, both pass the check, and both commit.
             var source = await FindAccount(dbContext, request.SourceAccountNumber, cancellationToken);
             var destination = await FindAccount(dbContext, request.DestinationAccountNumber, cancellationToken);
             var resolvedTags = await ResolveTags(tags, request.Tags, cancellationToken);
@@ -180,18 +157,11 @@ public sealed class CreateTransaction : IEndpoint
         var merchant = await merchants.Resolve(ToMerchantOption(request.Merchant!), cancellationToken)
                        ?? throw new MerchantNotFoundException(request.Merchant!.Label);
 
-        // Deposit and Withdraw reject an amount whose currency differs from the account's, so a USD
-        // transaction against a EUR account fails here rather than moving the wrong number.
         return destination is not null
             ? Domain.Entities.Transaction.Income(destination, amount, category, merchant, tags, occurredAt)
             : Domain.Entities.Transaction.Expense(source!, amount, category, merchant, tags, occurredAt);
     }
 
-    /// <summary>
-    /// Defensive: adding an entity and saving returns at least one write or throws. Reported against
-    /// the side the money was heading for, so a transfer names its destination rather than being
-    /// mislabelled as a plain deposit.
-    /// </summary>
     private static Exception Failure(Request request, Money amount, TransactionKind kind) =>
         kind == TransactionKind.Expense
             ? new WithdrawCreationFailedException(amount.ToDecimal(), request.SourceAccountNumber!)

--- a/src/Xpense/Xpense.API/Features/Transactions/ListTransactions.cs
+++ b/src/Xpense/Xpense.API/Features/Transactions/ListTransactions.cs
@@ -35,8 +35,6 @@ public sealed class ListTransactions : IEndpoint
         var totalPages = totalItems / pageSize + (totalItems % pageSize > 0 ? 1 : 0);
 
         var transactions = await query
-            // Ordered by when the money moved, not when the row was written. Those were the same
-            // column until OccurredAt became one of its own.
             .OrderByDescending(transaction => transaction.OccurredAt)
             .Skip(pageSize * (page - 1))
             .Take(pageSize)

--- a/src/Xpense/Xpense.API/Features/Transactions/TransactionQueries.cs
+++ b/src/Xpense/Xpense.API/Features/Transactions/TransactionQueries.cs
@@ -7,14 +7,6 @@ namespace Xpense.API.Features.Transactions;
 
 internal static class TransactionQueries
 {
-    /// <summary>
-    /// A transaction is only meaningful with its category, merchant, tags and both account sides,
-    /// and every read slice needs the same graph. Shared here rather than in a repository.
-    /// <para>
-    /// Both accounts are loaded because the response reports them by account number, and either
-    /// side may be absent -- a null side means the money crossed the system boundary.
-    /// </para>
-    /// </summary>
     public static IQueryable<Transaction> WithDetails(this XpenseDbContext dbContext) =>
         dbContext.Transactions
             .Include(transaction => transaction.Category)

--- a/src/Xpense/Xpense.API/Infrastructure/EndpointExtensions.cs
+++ b/src/Xpense/Xpense.API/Infrastructure/EndpointExtensions.cs
@@ -7,11 +7,6 @@ namespace Xpense.API.Infrastructure;
 
 public static class EndpointExtensions
 {
-    /// <summary>
-    /// Finds every <see cref="IEndpoint"/> in this assembly and invokes its static Map method.
-    /// This replaces the 31 hand-written AddScoped registrations the use-case layer needed:
-    /// adding a slice is now creating one file, with no registration step to forget.
-    /// </summary>
     public static void MapEndpoints(this IEndpointRouteBuilder app)
     {
         var endpoints = typeof(IEndpoint).Assembly

--- a/src/Xpense/Xpense.API/Infrastructure/HttpContextExtensions.cs
+++ b/src/Xpense/Xpense.API/Infrastructure/HttpContextExtensions.cs
@@ -5,15 +5,6 @@ namespace Xpense.API.Infrastructure;
 
 public static class HttpContextExtensions
 {
-    /// <summary>
-    /// Builds an absolute URL for a created resource.
-    /// <para>
-    /// MVC's CreatedAtAction emitted an absolute Location header; minimal APIs'
-    /// TypedResults.Created emits whatever string you hand it, so passing a path yields a
-    /// relative Location. Both are legal per RFC 9110, but the v1 contract is absolute, so
-    /// every create slice goes through here rather than each one deciding.
-    /// </para>
-    /// </summary>
     public static string ResourceUri(this HttpContext httpContext, string path) =>
         UriHelper.BuildAbsolute(httpContext.Request.Scheme, httpContext.Request.Host, path: path);
 }

--- a/src/Xpense/Xpense.API/Infrastructure/IEndpoint.cs
+++ b/src/Xpense/Xpense.API/Infrastructure/IEndpoint.cs
@@ -2,11 +2,6 @@ using Microsoft.AspNetCore.Routing;
 
 namespace Xpense.API.Infrastructure;
 
-/// <summary>
-/// Implemented by every slice. The member is static abstract so slices never need to be
-/// instantiated or registered in DI -- discovery is a reflection scan at startup and nothing
-/// else. See docs/vertical-slicing-architecture.
-/// </summary>
 public interface IEndpoint
 {
     static abstract void Map(IEndpointRouteBuilder app);

--- a/src/Xpense/Xpense.API/Infrastructure/ValidationEndpointFilter.cs
+++ b/src/Xpense/Xpense.API/Infrastructure/ValidationEndpointFilter.cs
@@ -7,11 +7,6 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Xpense.API.Infrastructure;
 
-/// <summary>
-/// Runs the registered FluentValidation validator for any argument that has one and throws on
-/// failure, so validation errors reach the client through the same ValidationExceptionHandler
-/// as before. Arguments without a validator pass through untouched.
-/// </summary>
 public sealed class ValidationEndpointFilter : IEndpointFilter
 {
     public async ValueTask<object> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
@@ -39,7 +34,6 @@ public sealed class ValidationEndpointFilter : IEndpointFilter
 
 public static class ValidationFilterExtensions
 {
-    /// <summary>Opt a slice into request validation.</summary>
     public static RouteHandlerBuilder Validated(this RouteHandlerBuilder builder) =>
         builder.AddEndpointFilter<ValidationEndpointFilter>();
 }

--- a/src/Xpense/Xpense.API/Program.cs
+++ b/src/Xpense/Xpense.API/Program.cs
@@ -7,7 +7,6 @@ using Xpense.API.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Activate Serilog
 builder.Host.UseSerilog((context, services, configuration) =>
 {
     configuration
@@ -18,7 +17,6 @@ builder.Host.UseSerilog((context, services, configuration) =>
 });
 
 builder.Services.AddSingleton<Serilog.ILogger>(_ => Log.Logger);
-// AddControllers used to bring these in implicitly; without MVC they must be explicit.
 builder.Services.AddCors();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.ConfigureSwagger();
@@ -30,33 +28,22 @@ builder.Services.AddHealthProbe();
 
 var app = builder.Build();
 
-// Nothing touches the database during startup. Migrations are a deployment step, applied by the
-// one-shot `migrations` container before this one starts, and the Priority reference data is part
-// of that schema rather than a boot-time write. See docs/adr/0004 and docs/adr/0005.
-// Locally, run `dotnet ef database update` before starting the API.
 
-// First in the pipeline so it wraps everything downstream. The registered IExceptionHandlers
-// decide the status and body; anything unclaimed falls through to FallbackExceptionHandler.
 app.UseExceptionHandler();
 
 app.UseStaticFiles("/static");
 app.UseRouting();
 app.UseCors(policy =>
 {
-    // TODO: later you need to find out how to distinguish between Local/Dev/Test/Production
     policy.WithOrigins("http://localhost:5173");
     policy.AllowAnyHeader();
     policy.AllowAnyMethod();
 });
 
-// Every slice, discovered by scanning for IEndpoint. There is no per-feature registration.
 app.MapEndpoints();
 
-// Deliberately not a slice: /health is infrastructure, not a feature, and has no contract to
-// version. It is the one route mapped outside Features/ -- see the carve-out in AGENTS.md.
 app.MapHealthChecks("/health");
 
-// Enable Swagger & Swagger UI
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();

--- a/src/Xpense/Xpense.Domain/Entities/Account.cs
+++ b/src/Xpense/Xpense.Domain/Entities/Account.cs
@@ -4,38 +4,18 @@ using Xpense.Domain.ValueObjects;
 
 namespace Xpense.Domain.Entities
 {
-    /// <summary>
-    /// An account holds money in exactly one currency.
-    /// <para>
-    /// The balance is stored in minor units rather than as a decimal so it shares a
-    /// representation with <see cref="ValueObjects.Money"/>. Previously it was a bare decimal
-    /// with no currency at all, which let a USD transfer move money out of a EUR account
-    /// without complaint.
-    /// </para>
-    /// <para>
-    /// There is no collection of transactions here. A <see cref="Transaction"/> points at up to
-    /// two accounts, so one navigation cannot express the relationship and two would only ever be
-    /// queried separately anyway.
-    /// </para>
-    /// </summary>
     public class Account : BaseEntity
     {
-        /// <summary>The human-readable name of the account.</summary>
         public required string Label { get; set; }
 
-        /// <summary>The public identifier of the account. <see cref="BaseEntity.Id"/> stays internal.</summary>
         public required string AccountNumber { get; set; }
 
-        /// <summary>Balance in minor units of <see cref="Currency"/>. Mapped; prefer <see cref="Balance"/>.</summary>
         public long BalanceMinorUnits { get; set; }
 
-        /// <summary>The currency this account is denominated in.</summary>
         public Currency Currency { get; set; }
 
-        /// <summary>The balance as money. Not mapped -- projected from the two columns above.</summary>
         public Money Balance => Money.OfMinorUnits(BalanceMinorUnits, Currency);
 
-        /// <summary>Whether this account is the default one for transactions.</summary>
         public bool IsDefault { get; set; }
 
         public void Deposit(Money amount)
@@ -52,10 +32,6 @@ namespace Xpense.Domain.Entities
             Touch();
         }
 
-        /// <summary>
-        /// There is no conversion here: an amount in another currency cannot be applied to this
-        /// account. Adding FX would mean converting before this point, never inside it.
-        /// </summary>
         private void RequireMatchingCurrency(Money amount)
         {
             if (amount.Currency != Currency)

--- a/src/Xpense/Xpense.Domain/Entities/BaseEntity.cs
+++ b/src/Xpense/Xpense.Domain/Entities/BaseEntity.cs
@@ -4,10 +4,6 @@ namespace Xpense.Domain.Entities
     {
         public int Id { get; set; }
 
-        /// <summary>
-        /// When Xpense wrote this row. Never set from a request -- a client says when the money
-        /// moved, which is <see cref="Transaction.OccurredAt"/>.
-        /// </summary>
         public DateTime CreatedAt { get; set; }
 
         public DateTime? UpdatedAt { get; set; }

--- a/src/Xpense/Xpense.Domain/Entities/Budget.cs
+++ b/src/Xpense/Xpense.Domain/Entities/Budget.cs
@@ -5,38 +5,12 @@ using Xpense.Domain.ValueObjects;
 
 namespace Xpense.Domain.Entities;
 
-/// <summary>
-/// An intended limit on expense for one category, in one currency, over a period.
-/// <para>
-/// A budget reports and never blocks. Nothing consults it when a transaction is recorded, because
-/// Xpense records money that has already moved -- refusing the record would not un-spend anything,
-/// it would only make Xpense disagree with the bank. See
-/// docs/adr/0006-a-budget-reports-and-never-blocks.md.
-/// </para>
-/// <para>
-/// Budgets do not know about each other. Several may cover one category at once, in different
-/// currencies, over different lengths, or over the very same days, and nothing here arbitrates
-/// between them: <c>Spent</c> and <c>Remaining</c> belong to a budget, not to a category. See
-/// docs/adr/0007-budgets-are-independent-of-one-another.md.
-/// </para>
-/// <para>
-/// One entity covers both shapes. A one-off is a budget with no <see cref="Recurrence"/> and a
-/// fixed window; a repeating one has a recurrence and may run indefinitely. A second entity
-/// differing by one column is the mistake ADR 0001 already corrected once.
-/// </para>
-/// </summary>
 public class Budget : BaseEntity
 {
-    /// <summary>The limit in minor units of <see cref="Currency"/>. Mapped; prefer <see cref="Amount"/>.</summary>
     public long AmountMinorUnits { get; set; }
 
-    /// <summary>
-    /// The currency this budget is stated in. Only expenses in this currency count toward it --
-    /// nothing converts, here or anywhere else in Xpense.
-    /// </summary>
     public Currency Currency { get; set; }
 
-    /// <summary>The limit as money. Not mapped -- projected from the two columns above.</summary>
     public Money Amount => Money.OfMinorUnits(AmountMinorUnits, Currency);
 
     public int CategoryId { get; set; }
@@ -45,16 +19,10 @@ public class Budget : BaseEntity
 
     public Recurrence Recurrence { get; set; }
 
-    /// <summary>The first day this budget is in force, as a UTC date.</summary>
     public DateTime StartsOn { get; set; }
 
-    /// <summary>
-    /// The last day this budget is in force, inclusive, as a UTC date. Null means it runs
-    /// indefinitely, which only a repeating budget may do.
-    /// </summary>
     public DateTime? EndsOn { get; set; }
 
-    /// <summary>The first instant after this budget's life. Open-ended budgets never reach it.</summary>
     private DateTime LifeToExclusive => EndsOn?.AddDays(1) ?? DateTime.MaxValue;
 
     public static Budget For(
@@ -81,11 +49,6 @@ public class Budget : BaseEntity
         };
     }
 
-    /// <summary>
-    /// Restates an existing budget's limit and window. The category is not among them: a budget for
-    /// a different category is a different budget, the same way an account's currency is fixed for
-    /// its life.
-    /// </summary>
     public void Restate(Money amount, Recurrence recurrence, DateTime startsOn, DateTime? endsOn)
     {
         if (amount.MinorUnits <= 0)
@@ -109,8 +72,6 @@ public class Budget : BaseEntity
         var from = UtcDate(startsOn);
         var to = endsOn is null ? null : (DateTime?)UtcDate(endsOn.Value);
 
-        // A budget that never repeats has exactly one window, so it has to say where that window
-        // stops. Open-ended only means anything for a repeating one.
         if (recurrence == Recurrence.None && to is null)
             throw new InvalidBudgetException("A budget that does not repeat must state when it ends.");
 
@@ -120,9 +81,6 @@ public class Budget : BaseEntity
         return (from, to);
     }
 
-    /// <summary>
-    /// The period this budget measures at the given instant, or null when it measures nothing then.
-    /// </summary>
     public BudgetPeriod? PeriodOn(DateTime instant)
     {
         if (Recurrence == Recurrence.None)
@@ -133,10 +91,6 @@ public class Budget : BaseEntity
 
         var period = CalendarPeriodContaining(instant);
 
-        // Whether a repeating budget is measuring is decided by the period overlapping its life,
-        // not by the instant being inside that life. A monthly budget starting on the 15th measures
-        // the whole of that month -- so asking about the 3rd has to give the same answer as asking
-        // about the 20th, or the same period would report two different totals.
         return period.Overlaps(StartsOn, LifeToExclusive) ? period : null;
     }
 
@@ -151,14 +105,6 @@ public class Budget : BaseEntity
         _ => throw new InvalidBudgetException($"Unsupported recurrence {Recurrence}.")
     };
 
-    /// <summary>
-    /// ISO 8601 weeks: Monday to Sunday, and week 1 is the one holding the first Thursday.
-    /// <para>
-    /// The year in the name comes from <see cref="ISOWeek.GetYear"/> and not from the instant,
-    /// because they disagree at the boundary -- 2027-01-01 falls in week 53 of 2026, and naming it
-    /// 2027-W53 would name a week that does not exist.
-    /// </para>
-    /// </summary>
     private static BudgetPeriod Week(DateTime instant)
     {
         var weekYear = ISOWeek.GetYear(instant);

--- a/src/Xpense/Xpense.Domain/Entities/Transaction.cs
+++ b/src/Xpense/Xpense.Domain/Entities/Transaction.cs
@@ -4,61 +4,36 @@ using Xpense.Domain.ValueObjects;
 
 namespace Xpense.Domain.Entities
 {
-    /// <summary>
-    /// A single recorded movement of money. One entity records all three kinds: each side is
-    /// either an account inside Xpense or nothing, and nothing means the money crossed the system
-    /// boundary -- in which case <see cref="Merchant"/> names who was on that side.
-    /// <para>
-    /// This replaced a <c>Transaction</c> naming one account plus a <c>Transfer</c> with two
-    /// <c>TransferLeg</c> rows. The legs held nothing their parent did not already hold. See
-    /// docs/adr/0001-one-transaction-entity-with-two-nullable-sides.md.
-    /// </para>
-    /// </summary>
     public class Transaction : BaseEntity
     {
-        /// <summary>Amount in minor units of <see cref="Currency"/>. Mapped; prefer <see cref="Amount"/>.</summary>
         public long AmountMinorUnits { get; set; }
 
         public Currency Currency { get; set; }
 
-        /// <summary>The amount as money. Not mapped -- projected from the two columns above.</summary>
         public Money Amount => Money.OfMinorUnits(AmountMinorUnits, Currency);
 
-        /// <summary>When the money actually moved, as told to Xpense. Distinct from <see cref="BaseEntity.CreatedAt"/>.</summary>
         public DateTime OccurredAt { get; set; }
 
-        /// <summary>Free text explaining why this happened.</summary>
         public string? Reason { get; set; }
 
-        /// <summary>The account money left. Null means it came from outside Xpense.</summary>
         public int? SourceAccountId { get; set; }
 
         public Account? SourceAccount { get; set; }
 
-        /// <summary>The account money arrived in. Null means it went outside Xpense.</summary>
         public int? DestinationAccountId { get; set; }
 
         public Account? DestinationAccount { get; set; }
 
-        /// <summary>Required when one side is outside Xpense; null on a transfer.</summary>
         public int? CategoryId { get; set; }
 
         public Category? Category { get; set; }
 
-        /// <summary>The party on the outside side. Required when one side is outside Xpense; null on a transfer.</summary>
         public int? MerchantId { get; set; }
 
         public Merchant? Merchant { get; set; }
 
         public virtual ICollection<Tag>? Tags { get; set; }
 
-        /// <summary>
-        /// Derived, never stored, so a row cannot contradict itself.
-        /// <para>
-        /// Both the foreign key and the navigation are checked because a transaction built by one
-        /// of the factories below carries navigations but no keys until it is saved.
-        /// </para>
-        /// </summary>
         public TransactionKind Kind =>
             !HasSource ? TransactionKind.Income
             : !HasDestination ? TransactionKind.Expense
@@ -68,7 +43,6 @@ namespace Xpense.Domain.Entities
 
         private bool HasDestination => DestinationAccountId is not null || DestinationAccount is not null;
 
-        /// <summary>Money arriving from outside Xpense.</summary>
         public static Transaction Income(
             Account destination,
             Money amount,
@@ -88,7 +62,6 @@ namespace Xpense.Domain.Entities
             return transaction;
         }
 
-        /// <summary>Money leaving for outside Xpense.</summary>
         public static Transaction Expense(
             Account source,
             Money amount,
@@ -108,10 +81,6 @@ namespace Xpense.Domain.Entities
             return transaction;
         }
 
-        /// <summary>
-        /// Money moving between two accounts inside Xpense. Carries neither category nor merchant:
-        /// there is no shop and no spending class, because the money is still yours.
-        /// </summary>
         public static Transaction Transfer(
             Account source,
             Account destination,
@@ -125,9 +94,6 @@ namespace Xpense.Domain.Entities
             if (ReferenceEquals(source, destination) || (source.Id != 0 && source.Id == destination.Id))
                 throw new InvalidTransactionException("Source and destination accounts must be different.");
 
-            // Xpense holds multiple currencies but does not convert between them. Both accounts and
-            // the amount have to agree; otherwise this moves the wrong quantity of money, which is
-            // exactly what it used to do when a balance was a currency-less decimal.
             if (source.Currency != destination.Currency)
                 throw new InvalidTransactionException(
                     "Cannot transfer between accounts in different currencies: "

--- a/src/Xpense/Xpense.Domain/Enums/CurrencyParser.cs
+++ b/src/Xpense/Xpense.Domain/Enums/CurrencyParser.cs
@@ -2,14 +2,6 @@ namespace Xpense.Domain.Enums;
 
 public static class CurrencyParser
 {
-    /// <summary>
-    /// Parses a currency name, case-insensitively, rejecting numeric input.
-    /// <para>
-    /// Enum.TryParse happily accepts "0" and any other number in range, which would let a
-    /// client post <c>"currency": "0"</c> and silently get EUR. Checking the value against the
-    /// defined names first is what stops that.
-    /// </para>
-    /// </summary>
     public static bool TryParse(string value, out Currency currency)
     {
         currency = default;

--- a/src/Xpense/Xpense.Domain/Enums/Recurrence.cs
+++ b/src/Xpense/Xpense.Domain/Enums/Recurrence.cs
@@ -1,14 +1,5 @@
 namespace Xpense.Domain.Enums;
 
-/// <summary>
-/// How a budget repeats. <see cref="None"/> means it covers one window and never comes back.
-/// <para>
-/// The repeating values name calendar periods rather than lengths of time, so every period a budget
-/// measures has a name -- 2026-W32, 2026-08, 2026 -- that a client, a report and a notification can
-/// all mean the same thing by. "Every 30 days" and "from the 25th" are deliberately not expressible:
-/// they would make a period something you compute rather than something you can refer to.
-/// </para>
-/// </summary>
 public enum Recurrence
 {
     None,

--- a/src/Xpense/Xpense.Domain/Enums/RecurrenceParser.cs
+++ b/src/Xpense/Xpense.Domain/Enums/RecurrenceParser.cs
@@ -2,14 +2,6 @@ namespace Xpense.Domain.Enums;
 
 public static class RecurrenceParser
 {
-    /// <summary>
-    /// Parses a recurrence name, case-insensitively, rejecting numeric input.
-    /// <para>
-    /// Same reason as <see cref="CurrencyParser"/>: <c>Enum.TryParse</c> accepts "0" and every other
-    /// number in range, so a client posting <c>"recurrence": "0"</c> would silently get
-    /// <see cref="Recurrence.None"/> -- and a budget that does not repeat when it was meant to.
-    /// </para>
-    /// </summary>
     public static bool TryParse(string value, out Recurrence recurrence)
     {
         recurrence = default;

--- a/src/Xpense/Xpense.Domain/Enums/TransactionKind.cs
+++ b/src/Xpense/Xpense.Domain/Enums/TransactionKind.cs
@@ -1,15 +1,5 @@
 namespace Xpense.Domain.Enums;
 
-/// <summary>
-/// Whether a transaction raised a balance from outside Xpense, lowered it to outside Xpense, or
-/// moved money between two accounts inside it.
-/// <para>
-/// Never stored. It is derived from which of a transaction's two sides name an account, so a row
-/// cannot claim a kind that contradicts its own columns. Replaces the stored
-/// <c>TransactionType { Credit, Debit, Transfer }</c>, whose Credit and Debit carried the opposite
-/// integer values to the deleted TransferLegDirection.
-/// </para>
-/// </summary>
 public enum TransactionKind
 {
     Income,

--- a/src/Xpense/Xpense.Domain/Exceptions/AccountExceptions.cs
+++ b/src/Xpense/Xpense.Domain/Exceptions/AccountExceptions.cs
@@ -13,10 +13,6 @@ public class AccountNotFoundException : NotFoundException
     }
 }
 
-/// <summary>
-/// An amount was applied to an account denominated in a different currency. Xpense holds
-/// multiple currencies but does not convert between them, so this is a 400, not a conversion.
-/// </summary>
 public class CurrencyMismatchException(string accountNumber, object accountCurrency, object amountCurrency)
     : DomainRuleViolationException(
         $"Account {accountNumber} is denominated in {accountCurrency}; an amount in {amountCurrency} cannot be applied to it.");

--- a/src/Xpense/Xpense.Domain/Exceptions/BudgetExceptions.cs
+++ b/src/Xpense/Xpense.Domain/Exceptions/BudgetExceptions.cs
@@ -1,9 +1,5 @@
 namespace Xpense.Domain.Exceptions;
 
-/// <summary>
-/// A budget was asked for that breaks its own rules -- a non-positive amount, an end before its
-/// start, or a one-off with no end at all.
-/// </summary>
 public class InvalidBudgetException(string message, Exception? innerException = null)
     : DomainRuleViolationException(message, innerException);
 

--- a/src/Xpense/Xpense.Domain/Exceptions/TransactionExceptions.cs
+++ b/src/Xpense/Xpense.Domain/Exceptions/TransactionExceptions.cs
@@ -9,10 +9,6 @@ public class DepositCreationFailedException(decimal amount, string accountNumber
 public class WithdrawCreationFailedException(decimal amount, string accountNumber, Exception? innerException = null)
     : PersistenceFailedException($"Failed Attempt to withdraw amount {amount} from account {accountNumber}", innerException);
 
-/// <summary>
-/// A transaction was asked for that cannot exist: a non-positive amount, or a transfer whose two
-/// accounts are the same or are denominated in different currencies.
-/// </summary>
 public class InvalidTransactionException(string message) : DomainRuleViolationException(message);
 
 public class InsufficientFundsForTransferException(int accountId, object balance, object amount)

--- a/src/Xpense/Xpense.Domain/Exceptions/XpenseException.cs
+++ b/src/Xpense/Xpense.Domain/Exceptions/XpenseException.cs
@@ -2,21 +2,11 @@ namespace Xpense.Domain.Exceptions;
 
 public class XpenseException(string message, Exception? innerException = null) : Exception(message, innerException);
 
-/// <summary>
-/// A resource was looked up by identity and does not exist. Maps to 404.
-/// </summary>
 public abstract class NotFoundException(string message, Exception? innerException = null)
     : XpenseException(message, innerException);
 
-/// <summary>
-/// A write we expected to succeed did not. The caller cannot fix this by changing the
-/// request, so it maps to 500 rather than 4xx.
-/// </summary>
 public abstract class PersistenceFailedException(string message, Exception? innerException = null)
     : XpenseException(message, innerException);
 
-/// <summary>
-/// The request was well-formed but breaks a domain rule. Maps to 400.
-/// </summary>
 public abstract class DomainRuleViolationException(string message, Exception? innerException = null)
     : XpenseException(message, innerException);

--- a/src/Xpense/Xpense.Domain/Options/MerchantOption.cs
+++ b/src/Xpense/Xpense.Domain/Options/MerchantOption.cs
@@ -2,11 +2,6 @@ using Xpense.Domain.Entities;
 
 namespace Xpense.Domain.Options;
 
-/// <summary>
-/// A client's reference to a merchant: an id, a label, or a label plus permission to create it.
-/// Named MerchantOption rather than Merchant so it stops colliding with the entity -- call
-/// sites used to need a `using ServiceMerchant = ...` alias.
-/// </summary>
 public class MerchantOption : IOption<Merchant>
 {
     public int? Id { get; set; }

--- a/src/Xpense/Xpense.Domain/Options/TagOption.cs
+++ b/src/Xpense/Xpense.Domain/Options/TagOption.cs
@@ -2,9 +2,6 @@ using Xpense.Domain.Entities;
 
 namespace Xpense.Domain.Options;
 
-/// <summary>
-/// A client's reference to a tag. See <see cref="MerchantOption"/> for the naming.
-/// </summary>
 public class TagOption : IOption<Tag>
 {
     public int? Id { get; set; }

--- a/src/Xpense/Xpense.Domain/ValueObjects/BudgetPeriod.cs
+++ b/src/Xpense/Xpense.Domain/ValueObjects/BudgetPeriod.cs
@@ -1,25 +1,8 @@
 namespace Xpense.Domain.ValueObjects;
 
-/// <summary>
-/// The window of time a budget measures expenses in, and the name that window goes by.
-/// <para>
-/// Half-open on purpose: <paramref name="From"/> is inside the period and
-/// <paramref name="ToExclusive"/> is not, so one period ends exactly where the next begins with no
-/// gap and no overlap. An inclusive end would mean choosing a last instant, and every choice of
-/// last instant is wrong for something -- 23:59:59 loses the final second, 23:59:59.9999999 is a
-/// number nobody would guess.
-/// </para>
-/// </summary>
-/// <param name="From">The first instant inside the period, in UTC.</param>
-/// <param name="ToExclusive">The first instant after the period, in UTC.</param>
-/// <param name="Name">
-/// What this period is called: <c>2026-W32</c>, <c>2026-08</c>, <c>2026</c>, or a date range for a
-/// budget that does not repeat.
-/// </param>
 public sealed record BudgetPeriod(DateTime From, DateTime ToExclusive, string Name)
 {
     public bool Contains(DateTime instant) => instant >= From && instant < ToExclusive;
 
-    /// <summary>Whether this period shares any time at all with the half-open window given.</summary>
     public bool Overlaps(DateTime from, DateTime toExclusive) => From < toExclusive && ToExclusive > from;
 }

--- a/src/Xpense/Xpense.Domain/ValueObjects/Money.cs
+++ b/src/Xpense/Xpense.Domain/ValueObjects/Money.cs
@@ -5,10 +5,6 @@ namespace Xpense.Domain.ValueObjects
 {
     public class Money(long minorUnits, Currency currency)
     {
-        /// <summary>
-        /// The amount as a whole number of the currency's smallest indivisible unit. Deliberately
-        /// not "cents": that holds for EUR and USD and is wrong for the first currency without them.
-        /// </summary>
         public long MinorUnits { get; } = minorUnits;
 
         public Currency Currency { get; } = currency;
@@ -47,10 +43,6 @@ namespace Xpense.Domain.ValueObjects
 
         public static bool operator >=(Money lhs, Money rhs) => Compare(lhs, rhs) >= 0;
 
-        /// <summary>
-        /// Comparing amounts in different currencies is meaningless, so it throws rather than
-        /// quietly returning an answer based on the raw numbers.
-        /// </summary>
         private static int Compare(Money lhs, Money rhs)
         {
             RequireSameCurrency(lhs, rhs);
@@ -63,8 +55,5 @@ namespace Xpense.Domain.ValueObjects
                 throw new IncompatibleCurrencyOperationException();
         }
 
-        // ponytail: no Money*Money or Money/Money. Multiplying two amounts yields money-squared
-        // and dividing yields a dimensionless ratio -- neither is a Money. Add Money*decimal
-        // scaling if a caller ever actually needs it.
     }
 }

--- a/src/Xpense/Xpense.Persistence/OptionResolver.cs
+++ b/src/Xpense/Xpense.Persistence/OptionResolver.cs
@@ -4,15 +4,6 @@ using Xpense.Domain.Options;
 
 namespace Xpense.Persistence;
 
-/// <summary>
-/// Resolves a client-supplied merchant or tag to a persisted entity: match by id, fall back to
-/// label, undelete a soft-deleted row, or create when the caller asked for it.
-/// <para>
-/// This survived the move to vertical slices as a shared service rather than being inlined,
-/// because the rules are subtle, two features depend on them, and getting them wrong silently
-/// duplicates merchants. It used to be OptionRepository&lt;T&gt;.GetOrCreateIfMissing.
-/// </para>
-/// </summary>
 public sealed class OptionResolver<TEntity>(XpenseDbContext dbContext)
     where TEntity : BaseEntity, IOptionEntity
 {
@@ -21,7 +12,6 @@ public sealed class OptionResolver<TEntity>(XpenseDbContext dbContext)
     public async Task<TEntity?> Resolve<TModel>(TModel model, CancellationToken cancellationToken = default)
         where TModel : IOption<TEntity>
     {
-        // Nothing to look up and no permission to create.
         if (!model.Create && !model.Id.HasValue)
             return null;
 
@@ -48,7 +38,6 @@ public sealed class OptionResolver<TEntity>(XpenseDbContext dbContext)
         return null;
     }
 
-    /// <summary>Soft-deleted rows are hidden by the global filter, so look past it and undelete.</summary>
     private async Task<TEntity?> Restore<TModel>(TModel model, CancellationToken cancellationToken)
         where TModel : IOption<TEntity>
     {

--- a/src/Xpense/Xpense.Persistence/TypeConfiguration/AccountEntityTypeConfiguration.cs
+++ b/src/Xpense/Xpense.Persistence/TypeConfiguration/AccountEntityTypeConfiguration.cs
@@ -15,10 +15,8 @@ public class AccountEntityTypeConfiguration : BaseEntityTypeConfiguration<Accoun
         builder.Property(account => account.AccountNumber).HasMaxLength(10).IsRequired().IsFixedLength();
         builder.Property(account => account.Currency).IsRequired();
 
-        // Balance is projected from BalanceMinorUnits + Currency, not stored.
         builder.Ignore(account => account.Balance);
 
-        // AccountNumber is the public identifier, so it has to be unique.
         builder.HasIndex(account => account.AccountNumber).IsUnique();
     }
 }

--- a/src/Xpense/Xpense.Persistence/TypeConfiguration/BudgetEntityTypeConfiguration.cs
+++ b/src/Xpense/Xpense.Persistence/TypeConfiguration/BudgetEntityTypeConfiguration.cs
@@ -11,23 +11,15 @@ public class BudgetEntityTypeConfiguration : BaseEntityTypeConfiguration<Budget>
         base.Configure(builder);
         builder.Metadata.SetSchema(XpenseSchema);
 
-        // Amount is projected from AmountMinorUnits and Currency, not stored.
         builder.Ignore(budget => budget.Amount);
 
-        // Budget (M) - Category (1). No collection on Category: nothing needs to walk that way, and
-        // adding one would put a navigation on Category that only this feature reads. Restrict
-        // because a category is soft-deleted rather than removed -- DeleteCategory soft-deletes the
-        // budgets pointing at it in the same operation.
         builder.HasOne(budget => budget.Category)
             .WithMany()
             .HasForeignKey(budget => budget.CategoryId)
             .OnDelete(DeleteBehavior.Restrict);
 
-        // Every read starts from a category and a window.
         builder.HasIndex(budget => new { budget.CategoryId, budget.StartsOn });
 
-        // The factory enforces these too. That is not redundancy to remove: a migration, a script or
-        // a future caller can write a row without going through it.
         builder.ToTable(table =>
         {
             table.HasCheckConstraint("CK_Budget_Amount_Positive", """ "AmountMinorUnits" > 0 """);
@@ -37,9 +29,5 @@ public class BudgetEntityTypeConfiguration : BaseEntityTypeConfiguration<Budget>
                 """ "EndsOn" IS NULL OR "EndsOn" >= "StartsOn" """);
         });
 
-        // "A budget that does not repeat must have an end" is deliberately *not* a check constraint.
-        // Saying it in SQL means writing the Recurrence enum's integer value into the schema, and an
-        // enum whose numbers ended up in two places is exactly how Credit and Debit came to disagree
-        // with TransferLegDirection. It lives in Budget.For and Budget.Restate instead.
     }
 }

--- a/src/Xpense/Xpense.Persistence/TypeConfiguration/CategoryEntityTypeConfiguration.cs
+++ b/src/Xpense/Xpense.Persistence/TypeConfiguration/CategoryEntityTypeConfiguration.cs
@@ -14,7 +14,6 @@ namespace Xpense.Persistence.TypeConfiguration
             builder.Property(category => category.Label).HasMaxLength(100).IsRequired();
             builder.HasIndex(category => category.Label).IsUnique();
 
-            // Category (1) - Transaction (M) 
             builder.HasMany(category => category.Transactions)
                 .WithOne(transaction => transaction.Category)
                 .HasForeignKey(transaction => transaction.CategoryId);

--- a/src/Xpense/Xpense.Persistence/TypeConfiguration/MerchantEntityTypeConfiguration.cs
+++ b/src/Xpense/Xpense.Persistence/TypeConfiguration/MerchantEntityTypeConfiguration.cs
@@ -12,12 +12,10 @@ namespace Xpense.Persistence.TypeConfiguration
             base.Configure(builder);
             builder.Metadata.SetSchema(XpenseSchema);
 
-            // Merchant names must be unique
             builder.HasIndex(merchant => merchant.Label).IsUnique();
 
             builder.Property(merchant => merchant.Label).HasMaxLength(100).IsRequired();
 
-            //  Merchant (M) - Transaction (1)
             builder.HasMany(merchant => merchant.Transactions)
                 .WithOne(transaction => transaction.Merchant)
                 .HasForeignKey(transaction => transaction.MerchantId);

--- a/src/Xpense/Xpense.Persistence/TypeConfiguration/PriorityEntityTypeConfiguration.cs
+++ b/src/Xpense/Xpense.Persistence/TypeConfiguration/PriorityEntityTypeConfiguration.cs
@@ -15,20 +15,11 @@ namespace Xpense.Persistence.TypeConfiguration
 
             builder.Property(priority => priority.Label).HasMaxLength(100).IsRequired();
 
-            // PriorityId (1) - Category (M)
             builder.HasMany(priority => priority.Categories).WithOne(category => category.Priority).HasForeignKey(category => category.PriorityId);
 
             SeedPriorities(builder);
         }
 
-        /// <summary>
-        /// Reference data, so it belongs to the schema rather than to application startup. See
-        /// docs/adr/0005-reference-data-lives-in-migrations.md.
-        /// <para>
-        /// <c>CreatedAt</c> is a literal on purpose: <c>DateTime.UtcNow</c> here makes the model
-        /// snapshot non-deterministic, and <c>migrations add</c> then emits a migration every run.
-        /// </para>
-        /// </summary>
         private static void SeedPriorities(EntityTypeBuilder<Priority> builder)
         {
             var seededAt = new DateTime(2026, 8, 5, 0, 0, 0, DateTimeKind.Utc);

--- a/src/Xpense/Xpense.Persistence/TypeConfiguration/TagEntityTypeConfiguration.cs
+++ b/src/Xpense/Xpense.Persistence/TypeConfiguration/TagEntityTypeConfiguration.cs
@@ -15,10 +15,8 @@ public class TagEntityTypeConfiguration : BaseEntityTypeConfiguration<Tag>
         builder.Property(tag => tag.BgColorHex).HasMaxLength(6).IsFixedLength();
         builder.Property(tag => tag.FgColorHex).HasMaxLength(6).IsFixedLength();
 
-        // Tag Name Index
         builder.HasIndex(tag => tag.Label).IsUnique();
 
-        // Tags (M) - Transactions (M)
         builder.HasMany(tag => tag.Transactions).WithMany(transaction => transaction.Tags).UsingEntity("TransactionTags",
            transactionSide => transactionSide.HasOne(typeof(Transaction)).WithMany().HasForeignKey("TransactionId").HasPrincipalKey(nameof(Transaction.Id)),
            tagSide => tagSide.HasOne(typeof(Tag)).WithMany().HasForeignKey("TagId").HasPrincipalKey(nameof(Tag.Id)),

--- a/src/Xpense/Xpense.Persistence/TypeConfiguration/TransactionEntityTypeConfiguration.cs
+++ b/src/Xpense/Xpense.Persistence/TypeConfiguration/TransactionEntityTypeConfiguration.cs
@@ -11,14 +11,11 @@ public class TransactionEntityTypeConfiguration : BaseEntityTypeConfiguration<Tr
         base.Configure(builder);
         builder.Metadata.SetSchema(XpenseSchema);
 
-        // Amount and Kind are projected, not stored.
         builder.Ignore(transaction => transaction.Amount);
         builder.Ignore(transaction => transaction.Kind);
 
         builder.Property(transaction => transaction.Reason).HasMaxLength(500);
 
-        // Two nullable sides. A null side means the money crossed the system boundary; there is no
-        // collection navigation on Account because one collection cannot express two foreign keys.
         builder.HasOne(transaction => transaction.SourceAccount)
             .WithMany()
             .HasForeignKey(transaction => transaction.SourceAccountId)
@@ -29,17 +26,14 @@ public class TransactionEntityTypeConfiguration : BaseEntityTypeConfiguration<Tr
             .HasForeignKey(transaction => transaction.DestinationAccountId)
             .OnDelete(DeleteBehavior.Restrict);
 
-        // Transaction (M) - Category(1), optional: a transfer has no spending class.
         builder.HasOne(transaction => transaction.Category)
             .WithMany(category => category.Transactions)
             .HasForeignKey(transaction => transaction.CategoryId);
 
-        // Transaction (M) - Merchant(1), optional: a transfer has no external party.
         builder.HasOne(transaction => transaction.Merchant)
             .WithMany(merchant => merchant.Transactions)
             .HasForeignKey(transaction => transaction.MerchantId);
 
-        // Transaction (M) - Tag(M)
         builder
             .HasMany(transaction => transaction.Tags)
             .WithMany(tag => tag.Transactions)
@@ -49,10 +43,6 @@ public class TransactionEntityTypeConfiguration : BaseEntityTypeConfiguration<Tr
                joinEntity => joinEntity.HasKey("TransactionId", "TagId")
             );
 
-        // The factories on Transaction enforce this, but they are not the only way a row can be
-        // written -- a migration, a script or a future caller could bypass them. Stated once here
-        // so the data itself cannot hold a transfer that claims a merchant, or a one-sided
-        // transaction with no classification at all.
         builder.ToTable(table => table.HasCheckConstraint(
             "CK_Transaction_Sides_And_Classification",
             """

--- a/src/Xpense/Xpense.Persistence/XpenseContextFactory.cs
+++ b/src/Xpense/Xpense.Persistence/XpenseContextFactory.cs
@@ -3,10 +3,6 @@ using Microsoft.EntityFrameworkCore.Design;
 
 namespace Xpense.Persistence;
 
-/// <summary>
-/// Used by `dotnet ef` at design time. The connection string only needs to be well-formed for
-/// migration scaffolding; it is not opened unless you actually run `database update`.
-/// </summary>
 public class XpenseContextFactory : IDesignTimeDbContextFactory<XpenseDbContext>
 {
     public XpenseDbContext CreateDbContext(string[] args)

--- a/src/Xpense/Xpense.Persistence/XpenseDbContext.cs
+++ b/src/Xpense/Xpense.Persistence/XpenseDbContext.cs
@@ -30,20 +30,6 @@ namespace Xpense.Persistence
             base.OnModelCreating(modelBuilder);
         }
 
-        /// <summary>
-        /// Every timestamp is stored and returned as UTC.
-        /// <para>
-        /// Reads: relational date columns carry no offset, so EF hands values back as
-        /// <see cref="DateTimeKind.Unspecified"/>. Tagging them UTC stops the DateTimeOffset
-        /// conversions in the response DTOs from silently applying the server's local offset.
-        /// </para>
-        /// <para>
-        /// Writes: Npgsql maps DateTime to `timestamp with time zone` and throws on any Kind
-        /// other than Utc. Local is converted; Unspecified is *tagged*, not converted, because
-        /// in this codebase an untagged value already means UTC -- calling ToUniversalTime on
-        /// it would shift it by the server's offset.
-        /// </para>
-        /// </summary>
         private static void ConfigureUtcDateTimes(ModelBuilder modelBuilder)
         {
             var utc = new ValueConverter<DateTime, DateTime>(

--- a/src/Xpense/Xpense.Tests/Architecture/SliceIsolationTests.cs
+++ b/src/Xpense/Xpense.Tests/Architecture/SliceIsolationTests.cs
@@ -6,16 +6,6 @@ using Xpense.API.Infrastructure;
 
 namespace Xpense.Tests.Architecture;
 
-/// <summary>
-/// The move to vertical slices gave up a compiler-enforced boundary: Xpense.Domain literally
-/// could not reference the API project, so a whole class of mistake was impossible. Slice
-/// isolation is only a convention, and a convention in a README is a weaker constraint than a
-/// build error -- for people and for AI agents alike.
-/// <para>
-/// These tests put that enforcement back. See
-/// docs/vertical-slicing-architecture/06-ai-assisted-development.md.
-/// </para>
-/// </summary>
 [TestFixture]
 public class SliceIsolationTests
 {
@@ -30,13 +20,6 @@ public class SliceIsolationTests
     [OneTimeTearDown]
     public void Dispose() => module?.Dispose();
 
-    /// <summary>
-    /// Contracts returned by more than one feature live in <c>Xpense.API.Contracts</c>, which is
-    /// outside Features and therefore always allowed. Analytics embeds a category, so
-    /// CategoryResponse cannot live inside the Categories feature without creating exactly the
-    /// slice-to-slice dependency this test forbids; MoneyResponse and Timestamps are there for the
-    /// same reason.
-    /// </summary>
     [Test]
     public void No_slice_references_a_type_from_another_feature()
     {
@@ -104,14 +87,9 @@ public class SliceIsolationTests
 
     private static bool IsInAFeature(TypeDefinition type) => type.FullName.StartsWith(FeaturesRoot);
 
-    /// <summary>"Xpense.API.Features.Tags.CreateTag/Request" -> "Tags".</summary>
     private static string FeatureOf(string fullName) =>
         fullName[FeaturesRoot.Length..].Split('.', '/')[0];
 
-    /// <summary>
-    /// Every type this type mentions: base type, interfaces, field and property types, method
-    /// signatures, and anything referenced from IL bodies.
-    /// </summary>
     private static IEnumerable<string> ReferencedTypeNames(TypeDefinition type)
     {
         if (type.BaseType is not null) yield return type.BaseType.FullName;

--- a/src/Xpense/Xpense.Tests/Infrastructure/FailOnSaveInterceptor.cs
+++ b/src/Xpense/Xpense.Tests/Infrastructure/FailOnSaveInterceptor.cs
@@ -3,15 +3,6 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace Xpense.Tests.Infrastructure;
 
-/// <summary>
-/// Forces the persistence layer to fail for a chosen entity type.
-/// <para>
-/// The old suite proved transfer atomicity by injecting a failing ITransferRepository. That
-/// injection point disappeared with the repository layer, so the equivalent now happens one
-/// level down: an EF interceptor that throws when the entity is about to be written. The
-/// slice's transaction scope should roll everything back.
-/// </para>
-/// </summary>
 public sealed class FailOnSaveInterceptor<TEntity> : SaveChangesInterceptor
     where TEntity : class
 {

--- a/src/Xpense/Xpense.Tests/Infrastructure/WebApiTestFactory.cs
+++ b/src/Xpense/Xpense.Tests/Infrastructure/WebApiTestFactory.cs
@@ -8,11 +8,6 @@ using Xpense.Persistence;
 
 namespace Xpense.Tests.Infrastructure;
 
-/// <summary>
-/// Hosts the API against a throwaway Postgres database created by
-/// <see cref="Integration.PostgresFixture"/>. The schema is already applied by the template, so
-/// nothing here creates tables.
-/// </summary>
 public sealed class WebApiTestFactory : WebApplicationFactory<Program>
 {
     private readonly string connectionString;
@@ -35,12 +30,6 @@ public sealed class WebApiTestFactory : WebApplicationFactory<Program>
         });
     }
 
-    /// <summary>
-    /// AddDbContext registers more than DbContextOptions&lt;T&gt;: it also registers the
-    /// non-generic DbContextOptions and, from EF 9 onwards, IDbContextOptionsConfiguration&lt;T&gt;.
-    /// Leaving any of them behind means two providers stay registered, which EF 10 rejects
-    /// outright ("Only a single database provider can be registered").
-    /// </summary>
     private static void RemoveProductionDbContext(IServiceCollection services)
     {
         var doomed = services

--- a/src/Xpense/Xpense.Tests/Integration/ApiEndpointTests.cs
+++ b/src/Xpense/Xpense.Tests/Integration/ApiEndpointTests.cs
@@ -14,11 +14,6 @@ using Xpense.Tests.Infrastructure;
 
 namespace Xpense.Tests.Integration;
 
-/// <summary>
-/// The canonical HTTP contract suite. Every endpoint, every error shape, one file.
-/// Each test gets its own Postgres database, cloned from the migrated template that
-/// <see cref="PostgresFixture"/> builds once per run.
-/// </summary>
 [TestFixture]
 public class ApiEndpointTests
 {
@@ -43,7 +38,6 @@ public class ApiEndpointTests
         factory?.Dispose();
     }
 
-    // ---------------------------------------------------------------- collections
 
     [TestCase("/api/v1/accounts", "Cash")]
     [TestCase("/api/v1/categories", "Food")]
@@ -64,7 +58,6 @@ public class ApiEndpointTests
         document.RootElement[0].GetProperty("label").GetString().Should().Be(expectedLabel);
     }
 
-    // ---------------------------------------------------------------- accounts
 
     [Test]
     public async Task Post_accounts_returns_the_created_resource_at_its_account_number_route()
@@ -81,7 +74,6 @@ public class ApiEndpointTests
         document.RootElement.GetProperty("accountNumber").GetString().Should().Be("1000000001");
         document.RootElement.GetProperty("label").GetString().Should().Be("Savings");
 
-        // The database key is not part of the contract, so it must not leak into the body.
         document.RootElement.TryGetProperty("id", out _).Should().BeFalse();
     }
 
@@ -128,7 +120,6 @@ public class ApiEndpointTests
         document.RootElement.GetProperty("updatedAt").ValueKind.Should().Be(JsonValueKind.Null);
     }
 
-    // ---------------------------------------------------------------- categories
 
     [Test]
     public async Task Post_categories_returns_the_created_resource_at_its_id_route()
@@ -175,7 +166,6 @@ public class ApiEndpointTests
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
 
-    // ---------------------------------------------------------------- tags
 
     [Test]
     public async Task Post_tags_returns_the_created_resource_at_its_id_route()
@@ -210,7 +200,6 @@ public class ApiEndpointTests
         var createResponse = await client.PostAsync("/api/v1/tags", NewTagBody("Travel"));
         createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        // "label" on update as well as create -- it used to be "name" on update only.
         var updateResponse = await client.PutAsync(
             "/api/v1/tags/1",
             JsonBody("{\"label\":\"Holiday\",\"bgColorHex\":\"#123456\",\"fgColorHex\":\"#abcdef\"}"));
@@ -222,10 +211,6 @@ public class ApiEndpointTests
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
 
-    // ---------------------------------------------------------------- transactions
-    //
-    // One resource, three kinds. Which sides the caller names decides the kind, so there is no
-    // type field: only a destination is income, only a source is expense, both is a transfer.
 
     [Test]
     public async Task Post_income_creates_a_direct_resource_and_uses_the_get_by_id_location()
@@ -268,11 +253,6 @@ public class ApiEndpointTests
         (await GetAccountBalance(seeded.AccountNumber)).Should().Be(1234);
     }
 
-    /// <summary>
-    /// OccurredAt and CreatedAt are separate facts. A transaction dated in the past keeps that date
-    /// while still recording when the row was written -- they were the same column until now, so a
-    /// backdated entry made it impossible to tell when anything was entered.
-    /// </summary>
     [Test]
     public async Task Post_transaction_keeps_the_supplied_occurrence_time_and_stamps_its_own_created_time()
     {
@@ -369,7 +349,6 @@ public class ApiEndpointTests
     [Test]
     public async Task Get_transactions_without_query_params_pages_by_default()
     {
-        // Used to bind page/pageSize to 0, fail FilterQuery.IsValid() and surface as a 500.
         var response = await client.GetAsync("/api/v1/transactions");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -455,15 +434,10 @@ public class ApiEndpointTests
         response.Content.Headers.ContentType!.MediaType.Should().Be(ProblemJson);
     }
 
-    // ---------------------------------------------------------------- transfers
-    //
-    // A transfer is a transaction with both sides named. There is no /transfers resource and no
-    // leg rows: the legs held nothing the parent did not already hold.
 
     [Test]
     public async Task Post_creates_an_atomic_transfer_naming_both_accounts()
     {
-        // Both accounts in USD: proves a non-default currency works end to end.
         var accounts = await SeedTransferAccounts(2000, 300, Currency.USD, Currency.USD);
         var occurredAt = new DateTimeOffset(2026, 7, 26, 9, 30, 0, TimeSpan.Zero);
 
@@ -489,7 +463,6 @@ public class ApiEndpointTests
         transfer.GetProperty("reason").GetString().Should().Be("Shared rent");
         transfer.GetProperty("occurredAt").GetDateTimeOffset().Should().Be(occurredAt);
 
-        // A transfer is money you still own, so it has no spending class and no external party.
         transfer.GetProperty("categoryId").ValueKind.Should().Be(JsonValueKind.Null);
         transfer.GetProperty("merchant").ValueKind.Should().Be(JsonValueKind.Null);
 
@@ -597,7 +570,6 @@ public class ApiEndpointTests
         response.Headers.Location.Should().NotBeNull();
         response.Headers.Location!.ToString().Should().MatchRegex("/api/v1/transactions/[1-9][0-9]*$");
 
-        // The header has to actually resolve -- a Location pointing at a 404 is worse than none.
         var followed = await client.GetAsync(response.Headers.Location);
         followed.StatusCode.Should().Be(HttpStatusCode.OK);
         using var document = JsonDocument.Parse(await followed.Content.ReadAsStringAsync());
@@ -608,8 +580,6 @@ public class ApiEndpointTests
     [Test]
     public async Task Transfer_rolls_back_entirely_when_persistence_fails()
     {
-        // Needs a host whose persistence layer fails, so it builds its own rather than using
-        // the fixture's. Replaces the old test that injected a failing ITransferRepository.
         using var failing = new WebApiTestFactory(
             await PostgresFixture.CreateDatabase(),
             new FailOnSaveInterceptor<Transaction>());
@@ -642,11 +612,6 @@ public class ApiEndpointTests
         (await verifyDb.Transactions.CountAsync()).Should().Be(0);
     }
 
-    // ---------------------------------------------------------------- multi-currency
-    //
-    // Accounts are denominated. Xpense holds several currencies but never converts between
-    // them, so anything that would mix currencies is rejected rather than silently moving the
-    // wrong quantity of money -- which is what happened when Balance was a bare decimal.
 
     [Test]
     public async Task Accounts_can_be_created_in_different_currencies()
@@ -677,7 +642,7 @@ public class ApiEndpointTests
 
         var response = await client.PostAsJsonAsync("/api/v1/transactions", new
         {
-            amount = new { minorUnits = 500, currency = "USD" },  // the account is EUR
+            amount = new { minorUnits = 500, currency = "USD" },
             sourceAccountNumber = seeded.AccountNumber,
             categoryId = seeded.CategoryId,
             merchant = new { label = "Coffee Shop", create = true }
@@ -689,7 +654,6 @@ public class ApiEndpointTests
         document.RootElement.GetProperty("detail").GetString()
             .Should().Contain("EUR").And.Contain("USD");
 
-        // Rejected before anything moved.
         (await GetAccountBalance(seeded.AccountNumber)).Should().Be(2000);
     }
 
@@ -730,7 +694,6 @@ public class ApiEndpointTests
         await AssertBalancesUnchanged(accounts, 2000, 300);
     }
 
-    // ---------------------------------------------------------------- analytics
 
     [Test]
     public async Task Get_spending_by_category_returns_the_current_summary_directly()
@@ -753,10 +716,6 @@ public class ApiEndpointTests
         expenses[0].GetProperty("amount").GetProperty("minorUnits").GetInt64().Should().Be(1250);
     }
 
-    /// <summary>
-    /// Spending means expenses. Transfers have no category to group by, and income is not spending
-    /// -- nothing filtered by direction before, so both would have been counted.
-    /// </summary>
     [Test]
     public async Task Get_spending_by_category_counts_neither_income_nor_transfers()
     {
@@ -771,10 +730,6 @@ public class ApiEndpointTests
         totals[0].GetProperty("minorUnits").GetInt64().Should().Be(1250);
     }
 
-    /// <summary>
-    /// This used to label the whole day with the first expense's currency and add every minor unit
-    /// together, so 12.50 EUR and 7.00 USD reported as 19.50 EUR -- money created by addition.
-    /// </summary>
     [Test]
     public async Task Get_spending_by_category_never_sums_across_currencies()
     {
@@ -791,7 +746,6 @@ public class ApiEndpointTests
             .Select(total => (total.GetProperty("currency").GetString(), total.GetProperty("minorUnits").GetInt64()))
             .Should().BeEquivalentTo([("EUR", 1250L), ("USD", 700L)]);
 
-        // One category, two currencies, so two lines -- never one line holding a nonsense sum.
         var expenses = document.RootElement.GetProperty("expenses");
         expenses.GetArrayLength().Should().Be(2);
         expenses.EnumerateArray()
@@ -799,12 +753,7 @@ public class ApiEndpointTests
             .Should().NotContain(1950);
     }
 
-    // ---------------------------------------------------------------- priorities
 
-    /// <summary>
-    /// Also proves the SeedPriorities migration ran: these five rows come from the schema, not from
-    /// anything this test wrote.
-    /// </summary>
     [Test]
     public async Task Get_priorities_returns_the_reference_data_seeded_by_the_migration()
     {
@@ -818,7 +767,6 @@ public class ApiEndpointTests
             .Should().Equal("Extreme", "High", "Medium", "Low", "None");
     }
 
-    // ---------------------------------------------------------------- budgets
 
     [Test]
     public async Task Post_budgets_returns_the_created_resource_at_its_id_route()
@@ -836,10 +784,6 @@ public class ApiEndpointTests
         document.RootElement.GetProperty("startsOn").GetString().Should().Be(FirstOfThisMonth());
     }
 
-    /// <summary>
-    /// A budget that does not repeat has exactly one window, so it has to say where that window ends.
-    /// Guarded by the validator here and by Budget.For underneath it.
-    /// </summary>
     [Test]
     public async Task Post_budgets_rejects_a_one_off_with_no_end()
     {
@@ -883,10 +827,6 @@ public class ApiEndpointTests
         period.GetProperty("exceeded").GetBoolean().Should().BeTrue();
     }
 
-    /// <summary>
-    /// A budget counts one currency. Spending the same category in another is reported as uncounted
-    /// rather than converted or, worse, added in.
-    /// </summary>
     [Test]
     public async Task Get_budgets_reports_spending_in_other_currencies_as_uncounted()
     {
@@ -904,10 +844,6 @@ public class ApiEndpointTests
         uncounted[0].GetProperty("minorUnits").GetInt64().Should().Be(700);
     }
 
-    /// <summary>
-    /// Spending means expenses. A transfer has no category to count against, and income is not
-    /// spending -- the same rule the analytics slice follows.
-    /// </summary>
     [Test]
     public async Task Get_budgets_counts_neither_income_nor_transfers()
     {
@@ -921,10 +857,6 @@ public class ApiEndpointTests
             .GetProperty("minorUnits").GetInt64().Should().Be(1250);
     }
 
-    /// <summary>
-    /// Two budgets on one category are two intentions, and Xpense reports both without arbitrating.
-    /// See docs/adr/0007-budgets-are-independent-of-one-another.md.
-    /// </summary>
     [Test]
     public async Task Get_budgets_reports_every_budget_on_a_category_without_choosing_between_them()
     {
@@ -970,10 +902,6 @@ public class ApiEndpointTests
         document.RootElement.GetArrayLength().Should().Be(0);
     }
 
-    /// <summary>
-    /// A budget on a category nobody can see measures nothing anyone can ask about. Without this,
-    /// the global query filter hides the category and budget reads meet a null one.
-    /// </summary>
     [Test]
     public async Task Delete_categories_also_deletes_the_budgets_pointing_at_it()
     {
@@ -998,11 +926,6 @@ public class ApiEndpointTests
         response.Content.Headers.ContentType!.MediaType.Should().Be(ProblemJson);
     }
 
-    // ---------------------------------------------------------------- error contract
-    //
-    // Before the exception handlers landed the API produced four different error shapes: two
-    // envelope variants (one camelCase, one PascalCase), bare 404s with no body, and real
-    // problem details. Nothing caught it because tests only asserted status codes.
 
     [Test]
     public async Task Unknown_account_returns_problem_details_not_an_envelope()
@@ -1018,7 +941,6 @@ public class ApiEndpointTests
         root.GetProperty("title").GetString().Should().Be("Resource not found");
         root.GetProperty("detail").GetString().Should().Contain("4242424242");
 
-        // The old Response<T> envelope leaked these two keys; they must never come back.
         root.TryGetProperty("statusCode", out _).Should().BeFalse();
         root.TryGetProperty("data", out _).Should().BeFalse();
     }
@@ -1031,7 +953,6 @@ public class ApiEndpointTests
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
         response.Content.Headers.ContentType!.MediaType.Should().Be(ProblemJson);
 
-        // Previously a bare NotFoundResult with an empty body.
         using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         document.RootElement.GetProperty("detail").GetString().Should().Contain("424242");
     }
@@ -1074,13 +995,11 @@ public class ApiEndpointTests
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
 
-        // FluentValidation reports "BgColorHex"; the contract is camelCase.
         document.RootElement.GetProperty("errors")
             .TryGetProperty("bgColorHex", out var colourErrors).Should().BeTrue();
         colourErrors[0].GetString().Should().Contain("hex colour");
     }
 
-    // ---------------------------------------------------------------- removed legacy routes
 
     [TestCase("/api/category")]
     [TestCase("/api/tag")]
@@ -1092,10 +1011,6 @@ public class ApiEndpointTests
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
-    /// <summary>
-    /// The account number addresses an account; the database key does not. "1" matches the route
-    /// pattern but is nobody's account number, so it resolves to a 404 rather than to account 1.
-    /// </summary>
     [TestCase("/api/account")]
     [TestCase("/api/account/1000000000")]
     [TestCase("/api/v1/accounts/1")]
@@ -1127,17 +1042,12 @@ public class ApiEndpointTests
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
-    // ---------------------------------------------------------------- helpers
 
     private static StringContent JsonBody(string json) => new(json, Encoding.UTF8, "application/json");
 
     private static StringContent NewTagBody(string label) =>
         JsonBody($"{{\"label\":\"{label}\",\"bgColorHex\":\"#ffffff\",\"fgColorHex\":\"#000000\"}}");
 
-    /// <summary>
-    /// Starts on the first of the current month so the budget is measuring today whatever day the
-    /// suite runs. A "None" recurrence deliberately gets no endsOn, which is what makes it invalid.
-    /// </summary>
     private static StringContent NewBudgetBody(int categoryId, long minorUnits, string recurrence) =>
         JsonBody(
             $"{{\"categoryId\":{categoryId},\"amount\":{{\"minorUnits\":{minorUnits},\"currency\":\"EUR\"}},"
@@ -1149,10 +1059,6 @@ public class ApiEndpointTests
         return new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc).ToString("yyyy-MM-dd");
     }
 
-    /// <summary>
-    /// The ISO week year is not always the calendar year -- 2027-01-01 sits in week 53 of 2026 -- so
-    /// the expected name is built the same way the domain builds it.
-    /// </summary>
     private static string IsoWeekName(DateTime instant) =>
         $"{System.Globalization.ISOWeek.GetYear(instant):0000}-W{System.Globalization.ISOWeek.GetWeekOfYear(instant):00}";
 
@@ -1209,16 +1115,11 @@ public class ApiEndpointTests
         }
     }
 
-    /// <summary>
-    /// One row per collection resource, so the collection assertions are real. Previously only
-    /// an account was seeded and the category/tag/merchant cases passed against an empty array.
-    /// </summary>
     private async Task SeedOneOfEachResource()
     {
         var dbContext = NewDbContext(out var scope);
         using (scope)
         {
-            // Link via navigation, not a hard-coded PriorityId, so EF orders the inserts.
             var priority = new Priority { Label = "Normal", Weight = 1, CreatedAt = DateTime.UtcNow };
             dbContext.Priorities.Add(priority);
             dbContext.Accounts.Add(NewAccount(SourceNumber, "Cash", 0, isDefault: true));
@@ -1281,10 +1182,6 @@ public class ApiEndpointTests
         }
     }
 
-    /// <summary>
-    /// One monthly EUR budget on Food, plus today's spending against it. Optionally spends the same
-    /// category in USD, and optionally adds income and a transfer that must not be counted.
-    /// </summary>
     private async Task SeedBudgetWithTodaysExpense(
         long limitMinorUnits,
         long spentMinorUnits,
@@ -1335,7 +1232,6 @@ public class ApiEndpointTests
         }
     }
 
-    /// <summary>Same category, same day, two currencies -- the case that used to be added together.</summary>
     private async Task SeedTodayExpensesInTwoCurrencies()
     {
         var dbContext = NewDbContext(out var scope);

--- a/src/Xpense/Xpense.Tests/Integration/PostgresFixture.cs
+++ b/src/Xpense/Xpense.Tests/Integration/PostgresFixture.cs
@@ -5,20 +5,6 @@ using Xpense.Persistence;
 
 namespace Xpense.Tests.Integration;
 
-/// <summary>
-/// One Postgres container for the whole integration run.
-/// <para>
-/// Integration tests used to run on SQLite in-memory, which is fast but is not the provider
-/// that ships. Postgres enforces things SQLite does not -- most relevantly it rejects a
-/// DateTime whose Kind is not Utc for a `timestamp with time zone` column, which is exactly the
-/// class of bug the UTC work was about.
-/// </para>
-/// <para>
-/// Per-test isolation comes from cloning a template database rather than migrating each time:
-/// CREATE DATABASE ... TEMPLATE is a file copy and costs a few milliseconds, where re-running
-/// migrations for every test would dominate the suite.
-/// </para>
-/// </summary>
 [SetUpFixture]
 public sealed class PostgresFixture
 {
@@ -40,8 +26,6 @@ public sealed class PostgresFixture
 
         await ExecuteOnMaintenanceDatabase($"CREATE DATABASE {TemplateDatabase}");
 
-        // Apply the real migrations once. If the Postgres migration is broken, the whole
-        // integration suite fails here rather than in a confusing place later.
         var options = new DbContextOptionsBuilder<XpenseDbContext>()
             .UseNpgsql(ConnectionStringFor(TemplateDatabase))
             .Options;
@@ -49,7 +33,6 @@ public sealed class PostgresFixture
         await using (var context = new XpenseDbContext(options))
             await context.Database.MigrateAsync();
 
-        // A template cannot be cloned while anything is connected to it.
         NpgsqlConnection.ClearAllPools();
     }
 
@@ -62,7 +45,6 @@ public sealed class PostgresFixture
             await container.DisposeAsync();
     }
 
-    /// <summary>Clones the migrated template and returns a connection string for the copy.</summary>
     public static async Task<string> CreateDatabase()
     {
         var name = $"xpense_test_{Interlocked.Increment(ref databaseCounter)}";

--- a/src/Xpense/Xpense.Tests/Unit/BudgetTests.cs
+++ b/src/Xpense/Xpense.Tests/Unit/BudgetTests.cs
@@ -6,15 +6,9 @@ using Entities = Xpense.Domain.Entities;
 
 namespace Xpense.Tests.Unit;
 
-/// <summary>
-/// Period arithmetic and the budget's own invariants. No persistence, so these are genuine unit
-/// tests; what a budget actually measures against real transactions is covered by the integration
-/// suite.
-/// </summary>
 [TestFixture]
 public class BudgetTests
 {
-    // A Thursday, comfortably inside week 32 of 2026 and the month of August.
     private static readonly DateTime InAugust = new(2026, 8, 6, 14, 0, 0, DateTimeKind.Utc);
 
     [Test]
@@ -28,10 +22,6 @@ public class BudgetTests
         period.ToExclusive.Should().Be(new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc));
     }
 
-    /// <summary>
-    /// A period runs to the start of the next one and no further, so the two never both claim an
-    /// instant and no instant falls between them.
-    /// </summary>
     [Test]
     public void A_period_excludes_its_end_and_includes_its_start()
     {
@@ -42,11 +32,6 @@ public class BudgetTests
         period.Contains(new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc)).Should().BeFalse();
     }
 
-    /// <summary>
-    /// The whole month, not the part after the budget began. Activity is decided by the period
-    /// overlapping the budget's life rather than by the instant being inside it -- otherwise asking
-    /// about the 3rd and asking about the 20th would give two different answers for one period.
-    /// </summary>
     [Test]
     public void A_monthly_budget_starting_mid_month_still_measures_the_whole_month()
     {
@@ -72,10 +57,6 @@ public class BudgetTests
         period.ToExclusive.Should().Be(new DateTime(2026, 8, 10, 0, 0, 0, DateTimeKind.Utc));
     }
 
-    /// <summary>
-    /// The ISO week year is not the calendar year at the boundary: 1 January 2027 belongs to week 53
-    /// of 2026. Naming it from the instant's year would produce 2027-W53, a week that does not exist.
-    /// </summary>
     [Test]
     public void A_weekly_period_is_named_by_its_iso_week_year_not_the_calendar_year()
     {
@@ -117,10 +98,6 @@ public class BudgetTests
         budget.PeriodOn(new DateTime(2026, 9, 2, 0, 0, 0, DateTimeKind.Utc)).Should().BeNull();
     }
 
-    /// <summary>
-    /// A one-off has one window, which is its own dates rather than any calendar period, and it is
-    /// named by them. Its end date is inclusive, so the last day still counts.
-    /// </summary>
     [Test]
     public void A_one_off_budget_measures_its_own_window_and_nothing_outside_it()
     {
@@ -171,10 +148,6 @@ public class BudgetTests
         act.Should().Throw<InvalidBudgetException>().WithMessage("*must be positive*");
     }
 
-    /// <summary>
-    /// The dates are dates. A budget starts on a day, so any time of day handed in is dropped rather
-    /// than kept to surprise a later comparison.
-    /// </summary>
     [Test]
     public void A_budget_keeps_only_the_date_part_of_its_window()
     {

--- a/src/Xpense/Xpense.Tests/Unit/TransactionTests.cs
+++ b/src/Xpense/Xpense.Tests/Unit/TransactionTests.cs
@@ -6,15 +6,6 @@ using Entities = Xpense.Domain.Entities;
 
 namespace Xpense.Tests.Unit;
 
-/// <summary>
-/// Replaces MoneyTransferTests. The rules that move money now live on the entity as three static
-/// factories, one per kind, so income and expense are guarded here too -- previously only transfers
-/// were, and the other two were protected by an endpoint validator alone.
-/// <para>
-/// No persistence dependency, so these are genuine unit tests. Rollback behaviour is covered by the
-/// integration tests that assert no balance changes survive a rejected transaction.
-/// </para>
-/// </summary>
 [TestFixture]
 public class TransactionTests
 {
@@ -108,7 +99,6 @@ public class TransactionTests
         var act = () => Entities.Transaction.Transfer(
             source, destination, Money.OfMinorUnits(100), null, null, OccurredAt);
 
-        // No conversion exists, so this cannot be honoured rather than merely being unsupported.
         act.Should().Throw<InvalidTransactionException>()
             .WithMessage("*different currencies*");
         source.BalanceMinorUnits.Should().Be(2000);
@@ -186,11 +176,6 @@ public class TransactionTests
         destination.BalanceMinorUnits.Should().Be(1000);
     }
 
-    /// <summary>
-    /// Kind reads the navigations as well as the foreign keys, because a transaction built by a
-    /// factory carries navigations and no keys until EF saves it. Reading only the keys would report
-    /// every unsaved transaction as income.
-    /// </summary>
     [Test]
     public void Kind_is_correct_before_the_transaction_is_saved()
     {


### PR DESCRIPTION
**551 lines of `///` across 49 files, removed.** What survives is `<summary>` on `*Request` and `*Response` records.

## Measured, not assumed

Which XML comments actually reach the generated document:

| Location | Reaches Swagger? |
|---|---|
| Endpoint classes and `Handle` methods | **No** — 30 operations, 0 with a summary or description |
| `*Request` / `*Response` records | **Yes** — 9 schema descriptions |
| `<param>` tags on record parameters | **No** — 0 property descriptions |
| Domain, Persistence, Tests | **No** — `IncludeXmlComments` names only the API assembly, so those XML files are never loaded |

Swashbuckle does not read class-level comments for minimal APIs, which is why the endpoint summaries produced nothing.

## The rule

A `///` block that reaches no reader is decoration. The generated document is the contract ([ADR 0003](docs/adr/0003-generated-openapi-is-the-contract.md)), so what earns `///` is a summary on a DTO. `//` stays for anything a reader of the code needs to know.

## Verified

- All 9 schema descriptions still present, `swagger.json` still 200
- 105 tests pass, build warning-free
- `NoWarn 1591` already covers missing-comment warnings, so nothing new appears

Pure deletion in 48 of the 49 files. Stacked; **base is `refactor/explicit-names`** (#52).